### PR TITLE
[Bug Fix] Fix race in engine_t and uncaught exception in app_t.

### DIFF
--- a/include/cocaine/detail/service/node/slave.hpp
+++ b/include/cocaine/detail/service/node/slave.hpp
@@ -135,16 +135,16 @@ public:
         return m_sessions.size();
     }
 
+    // Prepare all timers and spawn a worker instance.
+    void
+    activate();
+
 private:
     void
     do_assign(std::shared_ptr<session_t> session);
 
     void
     do_stop();
-
-    // Prepare all timers and spawn a worker instance.
-    void
-    activate();
 
     // Called on any read event from the worker.
     void

--- a/src/service/node/slave.cpp
+++ b/src/service/node/slave.cpp
@@ -97,7 +97,6 @@ slave_t::slave_t(const std::string& id,
     m_heartbeat_timer(asio),
     m_idle_timer(asio)
 {
-    asio.post(std::bind(&slave_t::activate, this));
 }
 
 slave_t::~slave_t() {


### PR DESCRIPTION
When pool was cleared before engine_t::activate was dispatched by loop
activate was performed on invalid pointer. Also sending errors during
engine_t::migrate and app_t::enqueue to disconnected client lead to
uncaught exceptions. This patch should fix this.