### PR TITLE
Preserve default spool.

### DIFF
--- a/include/cocaine/api/isolate.hpp
+++ b/include/cocaine/api/isolate.hpp
@@ -81,8 +81,10 @@ struct isolate_t {
             spool();
         } catch(const std::system_error& err) {
             cb(err.code());
+            return cancellation;
         } catch(...) {
             cb(std::make_error_code(std::errc::io_error));
+            return cancellation;
         }
 
         cb(std::error_code());

--- a/include/cocaine/detail/isolate/process.hpp
+++ b/include/cocaine/detail/isolate/process.hpp
@@ -52,8 +52,8 @@ public:
    ~process_t();
 
     virtual
-    std::unique_ptr<api::cancellation_t>
-    spool(callback_type cb);
+    void
+    spool();
 
     virtual
     std::unique_ptr<api::handle_t>

--- a/src/isolate/process/spooler.cpp
+++ b/src/isolate/process/spooler.cpp
@@ -30,34 +30,17 @@
 using namespace cocaine;
 using namespace cocaine::isolate;
 
-struct null_cancellation_t:
-    public api::cancellation_t
-{
-    void
-    cancel() {}
-};
+void
+process_t::spool() {
+    COCAINE_LOG_INFO(m_log, "deploying app to %s", m_working_directory);
 
-std::unique_ptr<api::cancellation_t>
-process_t::spool(callback_type cb) {
-    std::unique_ptr<api::cancellation_t> cancellation(new null_cancellation_t);
+    const auto storage = api::storage(m_context, "core");
+    const auto archive = storage->get<std::string>("apps", m_name);
 
-    try {
-        COCAINE_LOG_INFO(m_log, "deploying app to %s", m_working_directory);
-
-        const auto storage = api::storage(m_context, "core");
-        const auto archive = storage->get<std::string>("apps", m_name);
-
-    #if BOOST_VERSION >= 104600
-        archive_t(m_context, archive).deploy(m_working_directory.native());
-    #else
-        archive_t(m_context, archive).deploy(m_working_directory.string());
-    #endif
-
-        cb(std::error_code());
-    } catch (const std::system_error& err) {
-        cb(err.code());
-    }
-
-    return cancellation;
+#if BOOST_VERSION >= 104600
+    archive_t(m_context, archive).deploy(m_working_directory.native());
+#else
+    archive_t(m_context, archive).deploy(m_working_directory.string());
+#endif
 }
 

--- a/src/service/node/app.cpp
+++ b/src/service/node/app.cpp
@@ -177,7 +177,7 @@ public:
             profile.isolate.args
         );
 
-        spooler = isolate->spool(std::move(cb));
+        spooler = isolate->async_spool(std::move(cb));
     }
 
     ~spooling_t() {


### PR DESCRIPTION
### Added
New method: `async_spool`.

    Tries to spool an application non-blocking way (if possible).