### PR TITLE
[Headers] Do not change header while pushing to header table.

### DIFF
--- a/include/cocaine/rpc/asio/header.hpp
+++ b/include/cocaine/rpc/asio/header.hpp
@@ -318,7 +318,7 @@ public:
 
     inline
     void
-    push(header_t& header);
+    push(const header_t& header);
 
     inline
     size_t
@@ -459,7 +459,7 @@ header_table_t::empty() const {
 }
 
 void
-header_table_t::push(header_t& result) {
+header_table_t::push(const header_t& result) {
     size_t header_size = result.http2_size();
 
     // Pop headers from table until there is enough room for new one or table is empty
@@ -495,9 +495,6 @@ header_table_t::push(header_t& result) {
     // Encode value of the name of the header (plain copy)
     std::memcpy(dest, result.name.blob, result.name.size);
 
-    // Make header name point to data in the tabel. Size already was there. It did not change.
-    result.name.blob = dest;
-
     // Adjust buffer pointer
     dest += result.name.size;
 
@@ -506,9 +503,6 @@ header_table_t::push(header_t& result) {
 
     // Encode value of the value of the header (plain copy)
     std::memcpy(dest, result.value.blob, result.value.size);
-
-    // Make header value point to data in the table
-    result.value.blob = dest;
 
     // Adjust buffer pointer
     dest += result.value.size + http2_header_overhead;

--- a/tests/unit/header_table.cpp
+++ b/tests/unit/header_table.cpp
@@ -121,12 +121,12 @@ TEST(header_static_table_t, general) {
     const auto& headers = header_static_table_t::get_headers();
     ASSERT_EQ(headers.size(), boost::mpl::size<header_static_table_t::headers_storage>::value);
 
-    ASSERT_EQ(header_static_table_t::idx<headers::span_id<>>(), 1);
-    ASSERT_EQ(header_static_table_t::idx<headers::trace_id<>>(), 2);
+    ASSERT_EQ(header_static_table_t::idx<headers::trace_id<>>(), 1);
+    ASSERT_EQ(header_static_table_t::idx<headers::span_id<>>(), 2);
     ASSERT_EQ(header_static_table_t::idx<headers::parent_id<>>(), 3);
 
-    ASSERT_EQ(headers.at(1), io::headers::make_header<headers::span_id<>>());
-    ASSERT_EQ(headers.at(2), io::headers::make_header<headers::trace_id<>>());
+    ASSERT_EQ(headers.at(1), io::headers::make_header<headers::trace_id<>>());
+    ASSERT_EQ(headers.at(2), io::headers::make_header<headers::span_id<>>());
     ASSERT_EQ(headers.at(3), io::headers::make_header<headers::parent_id<>>());
 }
 
@@ -136,7 +136,7 @@ TEST(header_table_t, operator_sq_br) {
     ASSERT_DEATH(table[0], "");
     auto h = io::headers::make_header<headers::span_id<>>();
     table.push(h);
-    ASSERT_EQ(io::headers::make_header<headers::span_id<>>(), table[1]);
+    ASSERT_EQ(io::headers::make_header<headers::span_id<>>(), table[2]);
 }
 
 TEST(header_table_t, push) {


### PR DESCRIPTION
This behaviour is redundant and inconsistent. Now header is not changed
to point to data in the header table during push.