### PR TITLE
Updated Cocaine name in the init script for 0.12 version.

### DIFF
--- a/debian/cocaine-v12-runtime.init
+++ b/debian/cocaine-v12-runtime.init
@@ -14,7 +14,7 @@
 # Author: Andrey Sibiryov <kobolog@yandex-team.ru>
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
-NAME=cocaine-runtime
+NAME=cocaine-v12-runtime
 DAEMON=/usr/bin/cocaine-runtime
 DAEMON_ARGS="--daemonize"
 SCRIPTNAME=/etc/init.d/$NAME


### PR DESCRIPTION
A folder with Cocaine defaults has changed its name from `/etc/default/cocaine-runtime` to `/etc/default/cocaine-v12-runtime` since `v0.12`. The new path wasn't updated in the init script, causing troubles during the startup. This little fix solves the problem.