### PR TITLE
[Fix] Do not push trace scope if current scope is empty.

### DIFF
--- a/include/cocaine/hpack/header.h
+++ b/include/cocaine/hpack/header.h
@@ -1,0 +1,125 @@
+/*
+    Copyright (c) 2011-2015 Anton Matveenko <antmat@yandex-team.ru>
+    Copyright (c) 2011-2015 Other contributors as noted in the AUTHORS file.
+
+    This file is part of Cocaine.
+
+    Cocaine is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Cocaine is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef COCAINE_HPACK_HEADER_H
+#define COCAINE_HPACK_HEADER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Here and further "ch" is "cocaine hpack"
+ * ch_table is an opaque pointer to header table
+ */
+struct ch_table;
+
+/**
+ * Header data.
+ * Used to store header name and value.
+ */
+struct ch_header_data {
+    const char* blob;
+    size_t size;
+};
+
+/**
+ * Non-owning header entity.
+ * Contains name and value which points to some other resources.
+ */
+struct ch_header {
+    ch_header_data name;
+    ch_header_data value;
+};
+
+/**
+ * Creates header table.
+ * Should be destroyed after usage via ch_table_destroy
+ */
+ch_table*
+ch_table_init();
+
+/**
+ * Destroys header table.
+ */
+void
+ch_table_destroy(ch_table* table);
+
+/**
+ * Get a header from header table by index.
+ * idx should be valid index in table.
+ * Otherwise behaviour is undefined
+ */
+ch_header
+ch_table_get_header(ch_table* table, size_t idx);
+
+/**
+ * Push a header inside a header table.
+ * As far as table is implemented as a some kind of circular buffer
+ * this can result in removal of some old headers.
+ */
+void
+ch_table_push(ch_table*, const ch_header*);
+
+/**
+ * Try to find a header inside header table by exact match (name AND value).
+ * Returns index in a table or 0 if header was not found.
+ */
+size_t
+ch_table_find_by_full_match(ch_table*, const ch_header*);
+
+/**
+ * Try to find a header inside header table ONLY by name.
+ * Returns index in a table or 0 if header was not found.
+ */
+size_t
+ch_table_find_by_name(ch_table*, const ch_header*);
+
+/**
+ * Return data size of a header table.
+ */
+size_t
+ch_table_data_size(ch_table* table);
+
+/**
+ * Returns number of headers(including static) in header table.
+ */
+size_t
+ch_table_size(ch_table* table);
+
+/**
+ * Max capacity of a header table in bytes.
+ */
+size_t
+ch_table_data_capacity(ch_table* table);
+
+/**
+ * Checks if dynamic part of header table is empty.
+ */
+bool
+ch_table_empty(ch_table* table);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // COCAINE_HPACK_HEADER_H
+

--- a/include/cocaine/hpack/header.hpp
+++ b/include/cocaine/hpack/header.hpp
@@ -29,6 +29,8 @@
 #include <system_error>
 #include <vector>
 
+struct ch_header;
+
 namespace cocaine { namespace hpack {
 
 struct init_header_t;
@@ -151,6 +153,7 @@ public:
     header_t& operator=(const header_t&) = default;
     header_t(): name(), value() {}
 
+    header_t(const ch_header& c_header);
     // Create non-owning header on user-provided data
     template<class Header>
     static

--- a/include/cocaine/trace/trace_impl.hpp
+++ b/include/cocaine/trace/trace_impl.hpp
@@ -48,11 +48,15 @@ class trace_t::push_scope_t {
 public:
     template<class RpcStr>
     push_scope_t(const RpcStr& _rpc_name){
-        trace_t::current().push(_rpc_name);
+        if(!trace_t::current().empty()) {
+            trace_t::current().push(_rpc_name);
+        }
     }
 
     ~push_scope_t() {
-        trace_t::current().pop();
+        if(!trace_t::current().empty()) {
+            trace_t::current().pop();
+        }
     }
 };
 

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -1,4 +1,5 @@
 #include "cocaine/hpack/header.hpp"
+#include "cocaine/hpack/header.h"
 
 namespace cocaine { namespace hpack {
 
@@ -136,6 +137,10 @@ bool
 header_t::name_equal(const header_t& other) const {
     return name == other.name;
 }
+
+header_t::header_t(const ch_header& c_header) :
+    header_t(c_header.name.blob, c_header.name.size, c_header.value.blob, c_header.value.size)
+{}
 
 header_t::header_t(const header::data_t& _name, const header::data_t& _value) noexcept :
     name(_name),
@@ -327,3 +332,70 @@ header_table_t::operator[](size_t idx) {
 }
 
 }} // namespace cocaine::hpack
+
+
+extern "C" {
+
+struct ch_table {
+    cocaine::hpack::header_table_t table;
+};
+
+ch_table*
+ch_table_init() {
+    ch_table* data = new ch_table();
+    return data;
+}
+
+void
+ch_table_destroy(ch_table* table) {
+    delete table;
+}
+
+ch_header
+ch_table_get_header(ch_table* table, size_t idx) {
+    try {
+        auto h = table->table[idx];
+        return ch_header{{h.get_name().blob, h.get_name().size}, {h.get_value().blob, h.get_value().size}};
+    } catch(...) {
+        return ch_header();
+    }
+}
+
+void
+ch_table_push(ch_table* table, const ch_header* header) {
+    cocaine::hpack::header_t cpp_header(*header);
+    table->table.push(cpp_header);
+}
+
+size_t
+ch_table_find_by_full_match(ch_table* table, const ch_header* header) {
+    cocaine::hpack::header_t cpp_header(*header);
+    return table->table.find_by_full_match(cpp_header);
+}
+
+size_t
+ch_table_find_by_name(ch_table* table, const ch_header* header) {
+    cocaine::hpack::header_t cpp_header(*header);
+    return table->table.find_by_name(cpp_header);
+}
+
+size_t
+ch_table_data_size(ch_table* table) {
+    return table->table.data_size();
+}
+
+size_t
+ch_table_size(ch_table* table) {
+    return table->table.size();
+}
+
+size_t
+ch_table_data_capacity(ch_table* table) {
+    return table->table.data_capacity();
+}
+
+bool
+ch_table_empty(ch_table* table) {
+    return table->table.empty();
+}
+}

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -139,7 +139,8 @@ header_t::name_equal(const header_t& other) const {
 }
 
 header_t::header_t(const ch_header& c_header) :
-    header_t(c_header.name.blob, c_header.name.size, c_header.value.blob, c_header.value.size)
+    name({c_header.name.blob, c_header.name.size}),
+    value({c_header.value.blob, c_header.value.size})
 {}
 
 header_t::header_t(const header::data_t& _name, const header::data_t& _value) noexcept :


### PR DESCRIPTION
This fixes assertion on trace_t::push_scope_t instantiation on empty current trace.