### PR TITLE
[Continuum] Empty groups and groups with zero total weights are

### DIFF
--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -524,15 +524,23 @@ locator_t::on_refresh(const std::vector<std::string>& groups) {
 
         std::tie(lb, ub) = values.equal_range(*it);
 
-        if(lb == ub) return;
-
         auto group_log = std::make_unique<logging::log_t>(*m_log, attribute::set_t({
             attribute::make("rg", *it)
         }));
 
-        COCAINE_LOG_INFO(group_log, "routing group %s", lb != ub ? "updated" : "removed");
+        if(lb == ub) {
+            COCAINE_LOG_INFO(group_log, "routing group removed");
+            return;
+        }
 
-        mapping.insert({*it, continuum_t(std::move(group_log), lb->second)});
+        try {
+            mapping.insert({*it, continuum_t(std::move(group_log), lb->second)});
+            COCAINE_LOG_INFO(m_log, "routing group updated")("rg", *it);
+        } catch(const std::system_error& e) {
+            COCAINE_LOG_ERROR(m_log, "unable to update routing group: %s", e.what())(
+                "rg", *it
+            );
+        }
     });
 
     typedef std::vector<std::string> ruid_vector_t;

--- a/src/service/locator/routing.cpp
+++ b/src/service/locator/routing.cpp
@@ -45,6 +45,16 @@ continuum_t::continuum_t(std::unique_ptr<logging::log_t> log, const stored_type&
         weight
     );
 
+    if (!length) {
+        throw cocaine::error_t("group must not be empty");
+    }
+
+    // each item in a routing group has its own positive integer weight,
+    // so the total weight must be more than 0
+    if (weight < std::numeric_limits<double>::epsilon()) {
+        throw cocaine::error_t("the total weight of group must be positive");
+    }
+
     union digest_t {
         char       hashed[16];
         point_type points[sizeof(hashed) / sizeof(point_type)];


### PR DESCRIPTION
invalid now. Both of them make no sense from the routing point.

Also it fixes a bug with division by zero (Zero weight group) and a bug with dereferencing of NULL pointer if a group is empty. 