### PR TITLE
[Logs] Log e.what()

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -88,8 +88,8 @@ session_t::pull_action_t::finalize(const std::error_code& ec) {
             session->handle(message);
             message.clear();
         } catch(const std::system_error& e) {
-            COCAINE_LOG_ERROR(session->log, "uncaught invocation exception: [%d] %s", e.code().value(),
-                e.code().message());
+            COCAINE_LOG_ERROR(session->log, "uncaught invocation exception: [%d] %s",
+                e.code().value(), e.what());
             return session->detach(e.code());
         } catch(const std::exception& e) {
             COCAINE_LOG_ERROR(session->log, "uncaught invocation exception: %s", e.what());


### PR DESCRIPTION
This one
```
[E]: uncaught invocation exception: [22] Invalid trace parameters: 16622038451144834360 16622038451144834360 0: Invalid argument ...
[E]: uncaught invocation exception: [22] Invalid trace parameters: 16622038451144834360 16622038451144834360 0: Invalid argument
```
seems more useful, than
```
[E]: uncaught invocation exception: [22] Invalid argument 
```