### PR TITLE
[Zipkin] Do not limit values of zipkin traces. Remove optional.

### DIFF
--- a/include/cocaine/trace/trace.hpp
+++ b/include/cocaine/trace/trace.hpp
@@ -147,8 +147,8 @@ private:
     to_hex_string(uint64_t val);
 
     uint64_t trace_id;
-    state_t state;
-    boost::optional<state_t> previous_state;
+    state_t state, previous_state;
+    bool was_pushed;
 };
 
 class trace_t::restore_scope_t


### PR DESCRIPTION
Do not use optional is it is not movable in old versions of boost which
leads to wrapped handler being also non-movable.