### PR TITLE
misc(actor): changed prototype key name

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-core (0.12.4.2+nmu1) unstable; urgency=low
+
+  * Non-maintainer upload.
+  * misc(actor): changed prototype key name
+
+ -- Evgeny Safronov <division494@gmail.com>  Mon, 19 Oct 2015 13:00:22 +0300
+
 cocaine-core (0.12.4.1+nmu1) unstable; urgency=low
 
   * Non-maintainer upload.

--- a/src/actor_unix.cpp
+++ b/src/actor_unix.cpp
@@ -86,7 +86,7 @@ unix_actor_t::unix_actor_t(cocaine::context_t& context,
                            std::unique_ptr<cocaine::io::basic_dispatch_t> prototype) :
     m_context(context),
     endpoint(std::move(endpoint)),
-    m_log(context.log("core::io", {{ "app", prototype->name() }})),
+    m_log(context.log("core::io", {{ "service", prototype->name() }})),
     m_asio(asio),
     m_prototype(std::move(prototype)),
     fact(std::move(fact)),


### PR DESCRIPTION
From `app` to `service` just like in TCP actor.

@antmat TAL