### PR TITLE
fix(include): add missing include

### DIFF
--- a/include/cocaine/rpc/protocol.hpp
+++ b/include/cocaine/rpc/protocol.hpp
@@ -31,6 +31,8 @@
 #include <boost/mpl/insert_range.hpp>
 #include <boost/mpl/list.hpp>
 
+#include <cstdint>
+
 namespace cocaine { namespace io {
 
 namespace mpl = boost::mpl;


### PR DESCRIPTION
This fixes unicorn build (in unicorn protocol.hpp is first include, so uint64_t is undefined without this fix)