### PR TITLE
feat(config): several plugin paths can be specified now

### DIFF
--- a/debian/cocaine-runtime.conf
+++ b/debian/cocaine-runtime.conf
@@ -1,20 +1,23 @@
 {
     "version": 4,
     "logging": {
-        "core" : [
-            {
-                "formatter": {
-                    "type": "string",
-                    "sevmap": ["D", "I", "W", "E"],
-                    "pattern": "{severity}, {timestamp}: {message} :: {...}"
-                },
-                "sinks": [
-                    {
-                        "type": "console"
-                    }
-                ]
-            }
-        ]
+        "loggers" : {
+            "core" : [
+                {
+                    "formatter": {
+                        "type": "string",
+                        "sevmap": ["D", "I", "W", "E"],
+                        "pattern": "{severity}, {timestamp}: {message} :: {...}"
+                    },
+                    "sinks": [
+                        {
+                            "type": "console"
+                        }
+                    ]
+                }
+            ]
+        },
+        "severity" : "debug"
     },
     "network": {
         "pinned": {
@@ -22,7 +25,7 @@
         }
     },
     "paths": {
-        "plugins": "/usr/lib/cocaine",
+        "plugins": ["/usr/lib/cocaine"],
         "runtime": "/var/run/cocaine"
     },
     "services": {

--- a/include/cocaine/context/config.hpp
+++ b/include/cocaine/context/config.hpp
@@ -39,7 +39,8 @@ struct config_t {
 
 public:
     struct {
-        std::string plugins;
+        // Paths to load plugins from
+        std::vector<std::string> plugins;
         std::string runtime;
     } path;
 

--- a/include/cocaine/repository.hpp
+++ b/include/cocaine/repository.hpp
@@ -89,7 +89,7 @@ public:
    ~repository_t();
 
     void
-    load(const std::string& path);
+    load(const std::vector<std::string>& plugin_dirs);
 
     template<class Category, class... Args>
     typename category_traits<Category>::ptr_type

--- a/src/context/config.cpp
+++ b/src/context/config.cpp
@@ -274,7 +274,18 @@ config_t::config_t(const std::string& source) {
 
     // Path configuration
 
-    path.plugins = path_config.at("plugins", defaults::plugins_path).as_string();
+    // string argument for plugin folders is left for backward compatibility
+    // TODO: drop string argument as possible value on next config version change
+    const auto& plugins = path_config.at("plugins", defaults::plugins_path);
+    if(plugins.is_array()) {
+        for(const auto& plugin_entry: plugins.as_array()) {
+            path.plugins.push_back(plugin_entry.as_string());
+        }
+    } else if (plugins.is_string()) {
+        path.plugins.push_back(plugins.as_string());
+    } else {
+        throw cocaine::error_t("\"plugins\" value should be either string or array of strings", path.runtime);
+    }
     path.runtime = path_config.at("runtime", defaults::runtime_path).as_string();
 
     const auto runtime_path_status = fs::status(path.runtime);


### PR DESCRIPTION
Several plugin paths can be specified now, in this case 'paths.plugins' should be array of strings. Old config is also supported.
