### PR TITLE
refactor(context): change context to pimpl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,11 @@ ADD_LIBRARY(cocaine-core SHARED
     src/context/config.cpp
     src/context/mapper.cpp
     src/crypto.cpp
+    src/decoder.cpp
     src/defaults.cpp
     src/dispatch.cpp
     src/dynamic.cpp
+    src/encoder.cpp
     src/engine.cpp
     src/essentials.cpp
     src/gateway/adhoc.cpp

--- a/include/cocaine/common.hpp
+++ b/include/cocaine/common.hpp
@@ -24,20 +24,12 @@
 #include "cocaine/config.hpp"
 #include "cocaine/platform.hpp"
 
-#include <cstdint>
-#include <map>
-#include <string>
-#include <vector>
-
 #define BOOST_FILESYSTEM_VERSION 3
 #define BOOST_FILESYSTEM_NO_DEPRECATED
 
 #if !defined(COCAINE_DEBUG)
     #define BOOST_DISABLE_ASSERTS
 #endif
-
-#include <boost/assert.hpp>
-#include <boost/version.hpp>
 
 #define COCAINE_DECLARE_NONCOPYABLE(type)   \
     type(const type& other) = delete;       \
@@ -48,8 +40,6 @@
 #define COCAINE_UNUSED_(parameter)          \
     parameter __attribute__((unused))
 
-#include "cocaine/errors.hpp"
 #include "cocaine/forwards.hpp"
-#include "cocaine/memory.hpp"
 
 #endif

--- a/include/cocaine/context.hpp
+++ b/include/cocaine/context.hpp
@@ -31,64 +31,62 @@ namespace cocaine {
 
 // Context
 
-namespace signal {
-class handler_base_t;
-}
-
-
 class context_t {
-
-    struct impl_t;
-    struct impl_deleter_t {
-        void operator()(impl_t* ptr) const;
-    };
-    std::unique_ptr<impl_t, impl_deleter_t> impl;
-
 public:
-    context_t(config_t config, std::unique_ptr<logging::logger_t> log);
-   ~context_t();
+    virtual
+    ~context_t() {}
 
+    virtual
     std::unique_ptr<logging::logger_t>
-    log(const std::string& source);
+    log(const std::string& source) = 0;
 
+    virtual
     std::unique_ptr<logging::logger_t>
-    log(const std::string& source, blackhole::attributes_t attributes);
+    log(const std::string& source, blackhole::attributes_t attributes) = 0;
 
+    virtual
     const api::repository_t&
-    repository() const;
+    repository() const = 0;
 
+    virtual
     retroactive_signal<io::context_tag>&
-    signal_hub();
+    signal_hub() = 0;
 
+    virtual
     const config_t&
-    config() const;
+    config() const = 0;
 
+    virtual
     port_mapping_t&
-    mapper();
+    mapper() = 0;
 
     // Service API
+    virtual
     void
-    insert(const std::string& name, std::unique_ptr<actor_t> service);
+    insert(const std::string& name, std::unique_ptr<actor_t> service) = 0;
 
+    virtual
     auto
-    remove(const std::string& name) -> std::unique_ptr<actor_t>;
+    remove(const std::string& name) -> std::unique_ptr<actor_t> = 0;
 
+    virtual
     auto
-    locate(const std::string& name) const -> boost::optional<const actor_t&>;
+    locate(const std::string& name) const -> boost::optional<const actor_t&> = 0;
 
     // Network I/O
 
+    virtual
     auto
-    engine() -> execution_unit_t&;
+    engine() -> execution_unit_t& = 0;
 
+    virtual
     void
-    terminate();
-
-private:
-    void
-    bootstrap();
-
+    terminate() = 0;
 };
+
+std::unique_ptr<context_t>
+get_context(config_t config, std::unique_ptr<logging::logger_t> log);
+
 
 } // namespace cocaine
 

--- a/include/cocaine/context.hpp
+++ b/include/cocaine/context.hpp
@@ -98,12 +98,6 @@ private:
 
 };
 
-//template<class Category, class... Args>
-//typename api::category_traits<Category>::ptr_type
-//context_t::get(const std::string& type, Args&&... args) const {
-//    return m_repository->get<Category>(type, std::forward<Args>(args)...);
-//}
-
 } // namespace cocaine
 
 #endif

--- a/include/cocaine/context.hpp
+++ b/include/cocaine/context.hpp
@@ -37,7 +37,6 @@ class handler_base_t;
 
 
 class context_t {
-    COCAINE_DECLARE_NONCOPYABLE(context_t)
 
     struct impl_t;
     struct impl_deleter_t {
@@ -55,17 +54,19 @@ public:
     std::unique_ptr<logging::logger_t>
     log(const std::string& source, blackhole::attributes_t attributes);
 
-//    template<class Category, class... Args>
-//    typename api::category_traits<Category>::ptr_type
-//    get(const std::string& type, Args&&... args) const;
+    const api::repository_t&
+    repository() const;
 
-    const api::repository_t& repository() const;
+    retroactive_signal<io::context_tag>&
+    signal_hub();
+
+    const config_t&
+    config() const;
+
+    port_mapping_t&
+    mapper();
+
     // Service API
-
-    const config_t& config() const;
-
-    port_mapping_t& mapper() const;
-
     void
     insert(const std::string& name, std::unique_ptr<actor_t> service);
 
@@ -74,15 +75,6 @@ public:
 
     auto
     locate(const std::string& name) const -> boost::optional<const actor_t&>;
-
-    // Signals API
-
-    void
-    listen(const std::shared_ptr<dispatch<io::context_tag>>& slot, asio::io_service& asio);
-
-    template<class Event, class... Args>
-    void
-    invoke(const Args&... args);
 
     // Network I/O
 

--- a/include/cocaine/context/mapper.hpp
+++ b/include/cocaine/context/mapper.hpp
@@ -24,6 +24,7 @@
 #include "cocaine/common.hpp"
 
 #include <deque>
+#include <map>
 #include <mutex>
 
 namespace cocaine {

--- a/include/cocaine/detail/service/locator/routing.hpp
+++ b/include/cocaine/detail/service/locator/routing.hpp
@@ -23,6 +23,7 @@
 
 #include "cocaine/common.hpp"
 
+#include <map>
 #include <random>
 
 namespace cocaine { namespace service {

--- a/include/cocaine/format.hpp
+++ b/include/cocaine/format.hpp
@@ -25,14 +25,14 @@
 
 namespace cocaine { namespace aux {
 
-static inline
+inline
 std::string
 substitute(boost::format message) {
     return message.str();
 }
 
 template<typename T, class... Args>
-static inline
+inline
 std::string
 substitute(boost::format message, const T& argument, const Args&... args) {
     return substitute(std::move(message % argument), args...);
@@ -41,7 +41,7 @@ substitute(boost::format message, const T& argument, const Args&... args) {
 } // namespace aux
 
 template<class... Args>
-static inline
+inline
 std::string
 format(const std::string& format, const Args&... args) {
     try {

--- a/include/cocaine/forwards.hpp
+++ b/include/cocaine/forwards.hpp
@@ -51,6 +51,7 @@ class trace_t;
 
 template<class> class dispatch;
 template<class> class upstream;
+template<class> class retroactive_signal;
 
 class dynamic_t;
 

--- a/include/cocaine/forwards.hpp
+++ b/include/cocaine/forwards.hpp
@@ -41,7 +41,12 @@ class logger_t;
 
 namespace cocaine {
 
+class actor_t;
+struct config_t;
 class context_t;
+class execution_unit_t;
+class port_mapping_t;
+
 
 template<class> class dispatch;
 template<class> class upstream;
@@ -57,12 +62,16 @@ namespace cocaine { namespace api {
 struct cluster_t;
 struct gateway_t;
 struct isolate_t;
+class repository_t;
 struct service_t;
 struct storage_t;
 
 }} // namespace cocaine::api
 
 namespace cocaine { namespace io {
+
+// used for context signals
+struct context_tag;
 
 // I/O threads
 

--- a/include/cocaine/forwards.hpp
+++ b/include/cocaine/forwards.hpp
@@ -46,6 +46,7 @@ struct config_t;
 class context_t;
 class execution_unit_t;
 class port_mapping_t;
+class trace_t;
 
 
 template<class> class dispatch;
@@ -67,6 +68,13 @@ struct service_t;
 struct storage_t;
 
 }} // namespace cocaine::api
+
+namespace cocaine { namespace hpack {
+
+struct headers;
+struct header_static_table;
+
+}} // namespace cocaine::hpack
 
 namespace cocaine { namespace io {
 

--- a/include/cocaine/hpack/header.hpp
+++ b/include/cocaine/hpack/header.hpp
@@ -20,13 +20,8 @@
 
 #pragma once
 
-#include "cocaine/hpack/mpl.hpp"
-
 #include <array>
-#include <cassert>
-#include <cstring>
 #include <functional>
-#include <iostream>
 #include <system_error>
 #include <vector>
 
@@ -205,120 +200,6 @@ public:
     push_back(const header_t& header);
 };
 
-#include "header_definitions.ipp"
-
-struct header_static_table_t {
-    typedef boost::mpl::vector83<
-        headers::detail::empty_placeholder, // 0. Reserved
-        headers::authority<>,
-        headers::method<headers::default_values_t::get_value_t>,
-        headers::method<headers::default_values_t::post_value_t>,
-        headers::path<headers::default_values_t::root_value_t>,
-        headers::path<headers::default_values_t::index_value_t>,
-        headers::scheme<headers::default_values_t::http_value_t>,
-        headers::scheme<headers::default_values_t::https_value_t>,
-        headers::status<headers::default_values_t::status_200_value_t>,
-        headers::status<headers::default_values_t::status_204_value_t>,
-        headers::status<headers::default_values_t::status_206_value_t>,
-        headers::status<headers::default_values_t::status_304_value_t>,
-        headers::status<headers::default_values_t::status_400_value_t>,
-        headers::status<headers::default_values_t::status_404_value_t>,
-        headers::status<headers::default_values_t::status_500_value_t>,
-        headers::accept_charset<>,
-        headers::accept_encoding<headers::default_values_t::gzip_value_t>,
-        headers::accept_language<>,
-        headers::accept_ranges<>,
-        headers::accept<>,
-        headers::access_control_allow_origin<>,
-        headers::age<>,
-        headers::allow<>,
-        headers::authorization<>,
-        headers::cache_control<>,
-        headers::content_disposition<>,
-        headers::content_encoding<>,
-        headers::content_language<>,
-        headers::content_length<>,
-        headers::content_location<>,
-        headers::content_range<>,
-        headers::content_type<>,
-        headers::cookie<>,
-        headers::date<>,
-        headers::etag<>,
-        headers::expect<>,
-        headers::expires<>,
-        headers::from<>,
-        headers::host<>,
-        headers::if_match<>,
-        headers::if_modified_since<>,
-        headers::if_none_match<>,
-        headers::if_range<>,
-        headers::if_unmodified_since<>,
-        headers::last_modified<>,
-        headers::link<>,
-        headers::location<>,
-        headers::max_forwards<>,
-        headers::proxy_authenticate<>,
-        headers::proxy_authorization<>,
-        headers::range<>,
-        headers::referer<>,
-        headers::refresh<>,
-        headers::retry_after<>,
-        headers::server<>,
-        headers::set_cookie<>,
-        headers::strict_transport_security<>,
-        headers::transfer_encoding<>,
-        headers::user_agent<>,
-        headers::vary<>,
-        headers::via<>,
-        headers::www_authenticate<>, // 61
-        // Reserved for http2 extensions
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder,
-        headers::detail::empty_placeholder, // 79
-        // Cocaine specific headers
-        headers::trace_id<>,
-        headers::span_id<>,
-        headers::parent_id<>
-    > headers_storage;
-
-    static constexpr size_t size = boost::mpl::size<headers_storage>::type::value;
-    typedef std::array<header_t, size> storage_t;
-
-    static
-    constexpr
-    size_t
-    get_size() {
-        return size;
-    }
-
-    static
-    const storage_t&
-    get_headers();
-
-    template<class Header>
-    constexpr
-    static
-    size_t
-    idx() {
-        static_assert(boost::mpl::contains<headers_storage, Header>::type::value, "Could not find header in statis table");
-        return boost::mpl::find<headers_storage, Header>::type::pos::value;
-    }
-};
 
 // Header static and dynamic table as described in http2
 // See https://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#section-2.3

--- a/include/cocaine/hpack/header_definitions.hpp
+++ b/include/cocaine/hpack/header_definitions.hpp
@@ -20,6 +20,9 @@
 
 #pragma once
 
+namespace cocaine {
+namespace hpack {
+
 struct headers {
     friend struct header_static_table_t;
 
@@ -865,3 +868,6 @@ public:
         }
     };
 };
+
+} //  namespace hpack
+} //  namespace cocaine

--- a/include/cocaine/hpack/msgpack_traits.hpp
+++ b/include/cocaine/hpack/msgpack_traits.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "cocaine/hpack/header.hpp"
+#include "cocaine/hpack/static_table.hpp"
 
 #include <msgpack/pack.hpp>
 #include <msgpack/object.hpp>

--- a/include/cocaine/hpack/static_table.hpp
+++ b/include/cocaine/hpack/static_table.hpp
@@ -1,0 +1,125 @@
+
+#pragma once
+
+#include "cocaine/hpack/mpl.hpp"
+
+#include "cocaine/hpack/header_definitions.hpp"
+
+namespace cocaine { namespace hpack {
+
+struct header_static_table_t {
+    typedef boost::mpl::vector83 <
+    headers::detail::empty_placeholder, // 0. Reserved
+    headers::authority<>,
+    headers::method<headers::default_values_t::get_value_t>,
+    headers::method<headers::default_values_t::post_value_t>,
+    headers::path<headers::default_values_t::root_value_t>,
+    headers::path<headers::default_values_t::index_value_t>,
+    headers::scheme<headers::default_values_t::http_value_t>,
+    headers::scheme<headers::default_values_t::https_value_t>,
+    headers::status<headers::default_values_t::status_200_value_t>,
+    headers::status<headers::default_values_t::status_204_value_t>,
+    headers::status<headers::default_values_t::status_206_value_t>,
+    headers::status<headers::default_values_t::status_304_value_t>,
+    headers::status<headers::default_values_t::status_400_value_t>,
+    headers::status<headers::default_values_t::status_404_value_t>,
+    headers::status<headers::default_values_t::status_500_value_t>,
+    headers::accept_charset<>,
+    headers::accept_encoding<headers::default_values_t::gzip_value_t>,
+    headers::accept_language<>,
+    headers::accept_ranges<>,
+    headers::accept<>,
+    headers::access_control_allow_origin<>,
+    headers::age<>,
+    headers::allow<>,
+    headers::authorization<>,
+    headers::cache_control<>,
+    headers::content_disposition<>,
+    headers::content_encoding<>,
+    headers::content_language<>,
+    headers::content_length<>,
+    headers::content_location<>,
+    headers::content_range<>,
+    headers::content_type<>,
+    headers::cookie<>,
+    headers::date<>,
+    headers::etag<>,
+    headers::expect<>,
+    headers::expires<>,
+    headers::from<>,
+    headers::host<>,
+    headers::if_match<>,
+    headers::if_modified_since<>,
+    headers::if_none_match<>,
+    headers::if_range<>,
+    headers::if_unmodified_since<>,
+    headers::last_modified<>,
+    headers::link<>,
+    headers::location<>,
+    headers::max_forwards<>,
+    headers::proxy_authenticate<>,
+    headers::proxy_authorization<>,
+    headers::range<>,
+    headers::referer<>,
+    headers::refresh<>,
+    headers::retry_after<>,
+    headers::server<>,
+    headers::set_cookie<>,
+    headers::strict_transport_security<>,
+    headers::transfer_encoding<>,
+    headers::user_agent<>,
+    headers::vary<>,
+    headers::via<>,
+    headers::www_authenticate<>, // 61
+    // Reserved for http2 extensions
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder,
+    headers::detail::empty_placeholder, // 79
+    // Cocaine specific headers
+    headers::trace_id<>,
+    headers::span_id<>,
+    headers::parent_id<>
+    > headers_storage;
+
+    static constexpr size_t size = boost::mpl::size<headers_storage>::type::value;
+    typedef std::array <header_t, size> storage_t;
+
+    static
+    constexpr
+    size_t
+    get_size() {
+        return size;
+    }
+
+    static
+    const storage_t&
+    get_headers();
+
+    template<class Header>
+    constexpr
+    static
+    size_t
+    idx() {
+        static_assert(boost::mpl::contains<headers_storage, Header>::type::value,
+                      "Could not find header in statis table");
+        return boost::mpl::find<headers_storage, Header>::type::pos::value;
+    }
+};
+
+} //  namespace hpack
+} //  namespace cocaine

--- a/include/cocaine/repository.hpp
+++ b/include/cocaine/repository.hpp
@@ -22,7 +22,10 @@
 #define COCAINE_REPOSITORY_HPP
 
 #include "cocaine/common.hpp"
+#include "cocaine/errors.hpp"
+#include "cocaine/memory.hpp"
 
+#include <map>
 #include <typeinfo>
 #include <type_traits>
 

--- a/include/cocaine/rpc/asio/encoder.hpp
+++ b/include/cocaine/rpc/asio/encoder.hpp
@@ -21,21 +21,10 @@
 #ifndef COCAINE_IO_ENCODER_HPP
 #define COCAINE_IO_ENCODER_HPP
 
-#include "cocaine/errors.hpp"
-
 #include "cocaine/hpack/header.hpp"
-#include "cocaine/hpack/msgpack_traits.hpp"
-
 #include "cocaine/memory.hpp"
-
 #include "cocaine/rpc/protocol.hpp"
-
-#include "cocaine/trace/trace.hpp"
-
-#include "cocaine/traits.hpp"
 #include "cocaine/traits/tuple.hpp"
-
-#include <cstring>
 
 namespace cocaine { namespace io {
 
@@ -51,22 +40,10 @@ struct encoded_buffers_t {
 
     static const size_t kInitialBufferSize = 2048;
 
-    encoded_buffers_t():
-        offset(0)
-    {
-        vector.resize(kInitialBufferSize);
-    }
+    encoded_buffers_t();
 
     void
-    write(const char* data, size_t size) {
-        while(size > vector.size() - offset) {
-            vector.resize(vector.size() * 2);
-        }
-
-        std::memcpy(vector.data() + offset, data, size);
-
-        offset += size;
-    }
+    write(const char* data, size_t size);
 
     // Movable
 
@@ -86,14 +63,10 @@ struct encoded_message_t {
     friend struct io::encoder_t;
 
     auto
-    data() const -> const char* {
-        return buffer.vector.data();
-    }
+    data() const -> const char*;
 
     size_t
-    size() const {
-        return buffer.offset;
-    }
+    size() const;
 
 private:
     encoded_buffers_t buffer;
@@ -105,7 +78,7 @@ struct unbound_message_t {
     // Partially applied message encoding function.
     const function_type bind;
 
-    unbound_message_t(function_type&& bind_): bind(std::move(bind_)) { }
+    unbound_message_t(function_type&& bind_);
 };
 
 } // namespace aux
@@ -118,6 +91,7 @@ struct encoder_t {
 
     typedef aux::unbound_message_t message_type;
     typedef aux::encoded_message_t encoded_message_type;
+    typedef msgpack::packer<aux::encoded_buffers_t> packer_type;
 
     // TODO: Do we really need owning header storage?
     template<class Event, class... Args>
@@ -126,7 +100,7 @@ struct encoder_t {
     tether(encoder_t& encoder, uint64_t channel_id, const hpack::header_storage_t& headers, Args&... args) {
         aux::encoded_message_t message;
 
-        msgpack::packer<aux::encoded_buffers_t> packer(message.buffer);
+        packer_type packer(message.buffer);
 
         packer.pack_array(4);
 
@@ -140,32 +114,17 @@ struct encoder_t {
         type_traits<typename event_traits<Event>::argument_type>::pack(packer,
             std::forward<Args>(args)...);
 
-        // Optional message metadata
-
-        packer.pack_array(3);
-
-        uint64_t trace_id  = trace_t::current().get_trace_id();
-        uint64_t span_id   = trace_t::current().get_id();
-        uint64_t parent_id = trace_t::current().get_parent_id();
-
-        hpack::msgpack_traits::pack<hpack::headers::trace_id<>>(packer, encoder.hpack_context, hpack::header::create_data(trace_id));
-        hpack::msgpack_traits::pack<hpack::headers::span_id<>>(packer, encoder.hpack_context, hpack::header::create_data(span_id));
-        hpack::msgpack_traits::pack<hpack::headers::parent_id<>>(packer, encoder.hpack_context, hpack::header::create_data(parent_id));
-
-        for (const auto& header: headers.get_headers()) {
-            // TODO: maybe we need a runtime check not to pack headers twice
-            hpack::msgpack_traits::pack(packer, encoder.hpack_context, header);
-        }
-
+        encoder.pack_headers(packer, headers);
         return message;
     }
 
     aux::encoded_message_t
-    encode(const message_type& message) {
-        return message.bind(*this);
-    }
+    encode(const message_type& message);
 
 private:
+    void
+    pack_headers(packer_type& packer, const hpack::header_storage_t& headers);
+
     // HPACK HTTP/2.0 tables.
     hpack::header_table_t hpack_context;
 };

--- a/include/cocaine/rpc/asio/encoder.hpp
+++ b/include/cocaine/rpc/asio/encoder.hpp
@@ -26,6 +26,8 @@
 #include "cocaine/hpack/header.hpp"
 #include "cocaine/hpack/msgpack_traits.hpp"
 
+#include "cocaine/memory.hpp"
+
 #include "cocaine/rpc/protocol.hpp"
 
 #include "cocaine/trace/trace.hpp"

--- a/include/cocaine/rpc/asio/readable_stream.hpp
+++ b/include/cocaine/rpc/asio/readable_stream.hpp
@@ -22,6 +22,7 @@
 #define COCAINE_IO_BUFFERED_READABLE_STREAM_HPP
 
 #include "cocaine/errors.hpp"
+#include "cocaine/memory.hpp"
 
 #include <functional>
 

--- a/include/cocaine/rpc/slot.hpp
+++ b/include/cocaine/rpc/slot.hpp
@@ -27,6 +27,7 @@
 
 #include <boost/mpl/lambda.hpp>
 #include <boost/mpl/transform.hpp>
+#include <boost/optional/optional_fwd.hpp>
 
 namespace cocaine { namespace io {
 

--- a/include/cocaine/rpc/upstream.hpp
+++ b/include/cocaine/rpc/upstream.hpp
@@ -22,6 +22,7 @@
 #define COCAINE_IO_UPSTREAM_HPP
 
 #include "cocaine/rpc/session.hpp"
+#include "cocaine/trace/trace.hpp"
 
 namespace cocaine {
 

--- a/include/cocaine/trace/trace.hpp
+++ b/include/cocaine/trace/trace.hpp
@@ -23,8 +23,9 @@
 
 #include "cocaine/common.hpp"
 
-#include <boost/optional.hpp>
+#include <boost/optional/optional_fwd.hpp>
 
+#include <functional>
 #include <string>
 
 namespace cocaine {

--- a/include/cocaine/trace/trace.hpp
+++ b/include/cocaine/trace/trace.hpp
@@ -25,6 +25,8 @@
 
 #include <boost/optional.hpp>
 
+#include <string>
+
 namespace cocaine {
 
 class trace_t

--- a/include/cocaine/traits/error_code.hpp
+++ b/include/cocaine/traits/error_code.hpp
@@ -21,6 +21,7 @@
 #ifndef COCAINE_ERROR_CODE_SERIALIZATION_TRAITS_HPP
 #define COCAINE_ERROR_CODE_SERIALIZATION_TRAITS_HPP
 
+#include "cocaine/errors.hpp"
 #include "cocaine/traits.hpp"
 #include "cocaine/traits/tuple.hpp"
 

--- a/include/cocaine/traits/tuple.hpp
+++ b/include/cocaine/traits/tuple.hpp
@@ -21,10 +21,10 @@
 #ifndef COCAINE_TYPELIST_SERIALIZATION_TRAITS_HPP
 #define COCAINE_TYPELIST_SERIALIZATION_TRAITS_HPP
 
-#include "cocaine/traits.hpp"
-
-#include "cocaine/platform.hpp"
+#include "cocaine/common.hpp"
+#include "cocaine/format.hpp"
 #include "cocaine/rpc/tags.hpp"
+#include "cocaine/traits.hpp"
 
 #include <tuple>
 

--- a/src/actor.cpp
+++ b/src/actor.cpp
@@ -23,6 +23,9 @@
 #include "cocaine/api/service.hpp"
 
 #include "cocaine/context.hpp"
+#include "cocaine/context/config.hpp"
+#include "cocaine/context/mapper.hpp"
+#include "cocaine/idl/context.hpp"
 #include "cocaine/logging.hpp"
 
 #include "cocaine/detail/chamber.hpp"
@@ -161,7 +164,7 @@ actor_t::endpoints() const {
                                                 | tcp::resolver::query::numeric_service;
 
         begin = tcp::resolver(*m_asio).resolve(tcp::resolver::query(
-            m_context.config.network.hostname, std::to_string(local.port()),
+            m_context.config().network.hostname, std::to_string(local.port()),
             flags
         ));
     } catch(const std::system_error& e) {
@@ -198,7 +201,7 @@ actor_t::run() {
         tcp::endpoint endpoint;
 
         try {
-            endpoint = tcp::endpoint{m_context.config.network.endpoint, m_context.mapper.assign(m_prototype->name())};
+            endpoint = tcp::endpoint{m_context.config().network.endpoint, m_context.mapper().assign(m_prototype->name())};
         } catch(const std::system_error& e) {
             COCAINE_LOG_ERROR(m_log, "unable to assign a local endpoint to service: {}", error::to_string(e));
             throw;
@@ -244,5 +247,5 @@ actor_t::terminate() {
     m_asio->reset();
 
     // Mark this service's port as free.
-    m_context.mapper.retain(m_prototype->name());
+    m_context.mapper().retain(m_prototype->name());
 }

--- a/src/actor_unix.cpp
+++ b/src/actor_unix.cpp
@@ -1,4 +1,5 @@
 #include "cocaine/rpc/actor_unix.hpp"
+#include "cocaine/rpc/dispatch.hpp"
 
 #include <boost/filesystem/operations.hpp>
 
@@ -10,6 +11,8 @@
 
 #include <blackhole/attribute.hpp>
 #include <blackhole/logger.hpp>
+
+#include <boost/lexical_cast.hpp>
 
 using namespace cocaine;
 

--- a/src/actor_unix.cpp
+++ b/src/actor_unix.cpp
@@ -1,17 +1,16 @@
 #include "cocaine/rpc/actor_unix.hpp"
-#include "cocaine/rpc/dispatch.hpp"
-
-#include <boost/filesystem/operations.hpp>
 
 #include "cocaine/context.hpp"
-#include "cocaine/logging.hpp"
-
 #include "cocaine/detail/chamber.hpp"
 #include "cocaine/engine.hpp"
+#include "cocaine/logging.hpp"
+#include "cocaine/memory.hpp"
+#include "cocaine/rpc/dispatch.hpp"
 
 #include <blackhole/attribute.hpp>
 #include <blackhole/logger.hpp>
 
+#include <boost/filesystem/operations.hpp>
 #include <boost/lexical_cast.hpp>
 
 using namespace cocaine;

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -20,8 +20,8 @@
 
 #include "cocaine/api/unicorn.hpp"
 #include "cocaine/api/storage.hpp"
-
 #include "cocaine/context.hpp"
+#include "cocaine/context/config.hpp"
 
 namespace cocaine { namespace api {
 
@@ -29,12 +29,12 @@ namespace cocaine { namespace api {
 
 category_traits<storage_t>::ptr_type
 storage(context_t& context, const std::string& name) {
-    auto it = context.config.storages.find(name);
+    auto it = context.config().storages.find(name);
 
-    if(it == context.config.storages.end()) {
+    if(it == context.config().storages.end()) {
         throw std::system_error(std::make_error_code(std::errc::argument_out_of_domain), name);
     }
-    return context.get<storage_t>(it->second.type, context, name, it->second.args);
+    return context.repository().get<storage_t>(it->second.type, context, name, it->second.args);
 }
 
 // Unicorn
@@ -49,13 +49,13 @@ unicorn_t::unicorn_t(context_t& /*context*/, const std::string& /*name*/, const 
  */
 category_traits<unicorn_t>::ptr_type
 unicorn(context_t& context, const std::string& name) {
-    auto it = context.config.unicorns.find(name);
+    auto it = context.config().unicorns.find(name);
 
-    if(it == context.config.unicorns.end()) {
+    if(it == context.config().unicorns.end()) {
         throw std::system_error(std::make_error_code(std::errc::argument_out_of_domain), name);
     }
 
-    return context.get<unicorn_t>(it->second.type, context, name, it->second.args);
+    return context.repository().get<unicorn_t>(it->second.type, context, name, it->second.args);
 }
 
 }} // namespace cocaine::api

--- a/src/chamber.cpp
+++ b/src/chamber.cpp
@@ -20,6 +20,8 @@
 
 #include "cocaine/detail/chamber.hpp"
 
+#include "cocaine/memory.hpp"
+
 #include <iomanip>
 #include <sstream>
 

--- a/src/cluster/multicast.cpp
+++ b/src/cluster/multicast.cpp
@@ -21,6 +21,7 @@
 #include "cocaine/detail/cluster/multicast.hpp"
 
 #include "cocaine/context.hpp"
+#include "cocaine/dynamic.hpp"
 #include "cocaine/logging.hpp"
 
 #include "cocaine/rpc/dispatch.hpp"

--- a/src/cluster/multicast.cpp
+++ b/src/cluster/multicast.cpp
@@ -21,6 +21,7 @@
 #include "cocaine/detail/cluster/multicast.hpp"
 
 #include "cocaine/context.hpp"
+#include "cocaine/context/signal.hpp"
 #include "cocaine/dynamic.hpp"
 #include "cocaine/logging.hpp"
 
@@ -144,7 +145,7 @@ multicast_t::multicast_t(context_t& context, interface& locator, const std::stri
     m_signals = std::make_shared<dispatch<context_tag>>(name);
     m_signals->on<context::prepared>(std::bind(&multicast_t::on_publish, this, std::error_code()));
 
-    context.listen(m_signals, m_locator.asio());
+    context.signal_hub().listen(m_signals, m_locator.asio());
 }
 
 multicast_t::~multicast_t() {

--- a/src/cluster/predefine.cpp
+++ b/src/cluster/predefine.cpp
@@ -22,6 +22,7 @@
 
 
 #include "cocaine/context.hpp"
+#include "cocaine/context/signal.hpp"
 #include "cocaine/dynamic.hpp"
 #include "cocaine/logging.hpp"
 #include "cocaine/rpc/dispatch.hpp"
@@ -116,7 +117,7 @@ predefine_t::predefine_t(context_t& context, interface& locator, const std::stri
     m_signals = std::make_shared<dispatch<context_tag>>(name);
     m_signals->on<context::prepared>(std::bind(&predefine_t::on_announce, this, std::error_code()));
 
-    context.listen(m_signals, m_locator.asio());
+    context.signal_hub().listen(m_signals, m_locator.asio());
 }
 
 predefine_t::~predefine_t() {

--- a/src/cluster/predefine.cpp
+++ b/src/cluster/predefine.cpp
@@ -22,8 +22,9 @@
 
 
 #include "cocaine/context.hpp"
+#include "cocaine/dynamic.hpp"
 #include "cocaine/logging.hpp"
-
+#include "cocaine/rpc/dispatch.hpp"
 #include "cocaine/traits/endpoint.hpp"
 #include "cocaine/traits/graph.hpp"
 #include "cocaine/traits/vector.hpp"

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -21,13 +21,17 @@
 #include "cocaine/context.hpp"
 
 #include "cocaine/api/service.hpp"
-
-#include "cocaine/engine.hpp"
+#include "cocaine/context/config.hpp"
+#include "cocaine/context/mapper.hpp"
+#include "cocaine/context/signal.hpp"
 #include "cocaine/detail/essentials.hpp"
-
+#include "cocaine/engine.hpp"
+#include "cocaine/format.hpp"
+#include "cocaine/idl/context.hpp"
 #include "cocaine/logging.hpp"
-
 #include "cocaine/rpc/actor.hpp"
+
+#include <boost/optional.hpp>
 
 #include <boost/spirit/include/karma_char.hpp>
 #include <boost/spirit/include/karma_generate.hpp>
@@ -38,41 +42,167 @@
 #include <blackhole/scope/holder.hpp>
 #include <blackhole/wrapper.hpp>
 
-#include "cocaine/logging.hpp"
+#include <deque>
 
-using namespace cocaine;
+namespace cocaine {
+
 using namespace cocaine::io;
 
 using blackhole::scope::holder_t;
 
-context_t::context_t(config_t config_, std::unique_ptr<logging::logger_t> log_):
-    config(config_),
-    mapper(config_)
-{
-    m_log = std::move(log_);
+struct context_t::impl_t {
+    impl_t(config_t _config, std::unique_ptr<logging::logger_t> _log) :
+        log(std::move(_log)),
+        config(_config),
+        mapper(config)
+    {}
+    typedef std::deque<std::pair<std::string, std::unique_ptr<actor_t>>> service_list_t;
 
-    const holder_t scoped(*m_log, {{"source", "core"}});
+    // TODO: There was an idea to use the Repository to enable pluggable sinks and whatever else for
+    // for the Blackhole, when all the common stuff is extracted to a separate library.
+    std::unique_ptr<logging::logger_t> log;
 
-    COCAINE_LOG_INFO(m_log, "initializing the core");
+    // NOTE: This is the first object in the component tree, all the other dynamic components, be it
+    // storages or isolates, have to be declared after this one.
+    std::unique_ptr<api::repository_t> repository;
 
-    m_repository = std::make_unique<api::repository_t>(log("repository"));
+    // A pool of execution units - threads responsible for doing all the service invocations.
+    std::vector<std::unique_ptr<execution_unit_t>> pool;
+
+    // Services are stored as a vector of pairs to preserve the initialization order. Synchronized,
+    // because services are allowed to start and stop other services during their lifetime.
+    synchronized<service_list_t> services;
+
+    // Context signalling hub.
+    retroactive_signal<io::context_tag> signals;
+
+    const config_t config;
+
+    // Service port mapping and pinning.
+    port_mapping_t mapper;
+
+};
+
+void
+context_t::impl_deleter_t::operator()(impl_t* ptr) const {
+    delete ptr;
+}
+
+
+context_t::context_t(config_t config, std::unique_ptr<logging::logger_t> logger) :
+    impl(new impl_t(std::move(config), std::move(logger))) {
+
+    const holder_t scoped(*impl->log, {{"source", "core"}});
+
+    COCAINE_LOG_INFO(impl->log, "initializing the core");
+
+    impl->repository = std::make_unique<api::repository_t>(log("repository"));
 
     // Load the builtin plugins.
-    essentials::initialize(*m_repository);
+    essentials::initialize(*impl->repository);
 
     // Load the rest of plugins.
-    m_repository->load(config.path.plugins);
+    impl->repository->load(impl->config.path.plugins);
 
     // Spin up all the configured services, launch execution units.
-    bootstrap();
+    COCAINE_LOG_INFO(impl->log, "starting {:d} execution unit(s)", config.network.pool);
+
+    while (impl->pool.size() != config.network.pool) {
+        impl->pool.emplace_back(std::make_unique<execution_unit_t>(*this));
+    }
+
+    COCAINE_LOG_INFO(impl->log, "starting {:d} service(s)", config.services.size());
+
+    std::vector<std::string> errored;
+
+    for (auto it = config.services.begin(); it != config.services.end(); ++it) {
+        const holder_t scoped(*impl->log, {{"service", it->first}});
+
+        const auto asio = std::make_shared<asio::io_service>();
+
+        COCAINE_LOG_DEBUG(impl->log, "starting service");
+
+        try {
+            insert(it->first, std::make_unique<actor_t>(*this, asio, repository().get<api::service_t>(
+            it->second.type,
+            *this,
+            *asio,
+            it->first,
+            it->second.args
+            )));
+        } catch (const std::system_error& e) {
+            COCAINE_LOG_ERROR(impl->log, "unable to initialize service: {}", error::to_string(e));
+            errored.push_back(it->first);
+        } catch (const std::exception& e) {
+            COCAINE_LOG_ERROR(impl->log, "unable to initialize service: {}", e.what());
+            errored.push_back(it->first);
+        }
+    }
+
+    if (!errored.empty()) {
+        COCAINE_LOG_ERROR(impl->log, "emergency core shutdown");
+
+        // Signal and stop all the services, shut down execution units.
+        terminate();
+
+        std::ostringstream stream;
+        std::ostream_iterator<char> builder(stream);
+
+        boost::spirit::karma::generate(builder, boost::spirit::karma::string % ", ", errored);
+
+        throw cocaine::error_t("couldn't start core because of %d service(s): %s",
+                               errored.size(), stream.str()
+        );
+    } else {
+        impl->signals.invoke<io::context::prepared>();
+    }
 }
 
 context_t::~context_t() {
-    const holder_t scoped(*m_log, {{"source", "core"}});
+    const holder_t scoped(*impl->log, {{"source", "core"}});
 
     // Signal and stop all the services, shut down execution units.
     terminate();
 }
+
+void
+context_t::listen(const std::shared_ptr<dispatch<io::context_tag>>& slot, asio::io_service& asio) {
+    impl->signals.listen(slot, asio);
+}
+
+template<class Event, class... Args>
+void
+context_t::invoke(const Args&... args) {
+    impl->signals.invoke<Event>(args...);
+}
+
+template
+void
+context_t::invoke<io::context::os_signal, int, siginfo_t>(const int&, const siginfo_t&);
+
+template
+void
+context_t::invoke<io::context::prepared>();
+
+template
+void
+context_t::invoke<io::context::shutdown>();
+
+template
+void
+context_t::invoke<io::context::service::exposed,
+                  std::string,
+                  std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>>(
+    const std::string&,
+    const std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>&);
+
+template
+void
+context_t::invoke<io::context::service::removed,
+                  std::string,
+                  std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>>(
+    const std::string&,
+    const std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>&);
 
 std::unique_ptr<logging::logger_t>
 context_t::log(const std::string& source) {
@@ -84,7 +214,22 @@ context_t::log(const std::string& source, blackhole::attributes_t attributes) {
     attributes.push_back({"source", {source}});
 
     // TODO: Make it possible to use in-place operator+= to fill in more attributes?
-    return std::make_unique<blackhole::wrapper_t>(*m_log, std::move(attributes));
+    return std::make_unique<blackhole::wrapper_t>(*impl->log, std::move(attributes));
+}
+
+const api::repository_t&
+context_t::repository() const {
+    return *impl->repository;
+}
+
+const config_t&
+context_t::config() const {
+    return impl->config;
+}
+
+port_mapping_t&
+context_t::mapper() const {
+    return impl->mapper;
 }
 
 namespace {
@@ -103,62 +248,63 @@ struct match {
 
 void
 context_t::insert(const std::string& name, std::unique_ptr<actor_t> service) {
-    const holder_t scoped(*m_log, {{"source", "core"}});
+    const holder_t scoped(*impl->log, {{"source", "core"}});
 
     const actor_t& actor = *service;
 
-    m_services.apply([&](service_list_t& list) {
-        if(std::count_if(list.begin(), list.end(), match{name})) {
+    impl->services.apply([&](impl_t::service_list_t& list) {
+        if (std::count_if(list.begin(), list.end(), match{name})) {
             throw cocaine::error_t("service '%s' already exists", name);
         }
 
         service->run();
 
-        COCAINE_LOG_DEBUG(m_log, "service has been started", {
-            {"service", {name}}
+        COCAINE_LOG_DEBUG(impl->log, "service has been started", {
+            { "service", { name }}
         });
 
         list.emplace_back(name, std::move(service));
     });
 
     // Fire off the signal to alert concerned subscribers about the service removal event.
-    m_signals.invoke<context::service::exposed>(actor.prototype().name(), std::forward_as_tuple(
-        actor.endpoints(),
-        actor.prototype().version(),
-        actor.prototype().root()
+    impl->signals.invoke<context::service::exposed>(actor.prototype().name(), std::forward_as_tuple(
+    actor.endpoints(),
+    actor.prototype().version(),
+    actor.prototype().root()
     ));
 }
 
 std::unique_ptr<actor_t>
 context_t::remove(const std::string& name) {
-    const holder_t scoped(*m_log, {{"source", "core"}});
+    const holder_t scoped(*impl->log, {{"source", "core"}});
 
     std::unique_ptr<actor_t> service;
 
-    m_services.apply([&](service_list_t& list) {
+    impl->services.apply([&](impl_t::service_list_t& list) {
         auto it = std::find_if(list.begin(), list.end(), match{name});
 
-        if(it == list.end()) {
+        if (it == list.end()) {
             throw cocaine::error_t("service '%s' doesn't exist", name);
         }
 
-        service = std::move(it->second); list.erase(it);
+        service = std::move(it->second);
+        list.erase(it);
     });
 
     service->terminate();
 
-    COCAINE_LOG_DEBUG(m_log, "service has been stopped", {
-        {"service", name}
+    COCAINE_LOG_DEBUG(impl->log, "service has been stopped", {
+        { "service", name }
     });
 
     // Service is already terminated, so there's no reason to try to get its endpoints.
     std::vector<asio::ip::tcp::endpoint> nothing;
 
     // Fire off the signal to alert concerned subscribers about the service termination event.
-    m_signals.invoke<context::service::removed>(service->prototype().name(), std::forward_as_tuple(
-        nothing,
-        service->prototype().version(),
-        service->prototype().root()
+    impl->signals.invoke<context::service::removed>(service->prototype().name(), std::forward_as_tuple(
+    nothing,
+    service->prototype().version(),
+    service->prototype().root()
     ));
 
     return service;
@@ -166,10 +312,10 @@ context_t::remove(const std::string& name) {
 
 boost::optional<const actor_t&>
 context_t::locate(const std::string& name) const {
-    auto ptr = m_services.synchronize();
-    auto it  = std::find_if(ptr->begin(), ptr->end(), match{name});
+    auto ptr = impl->services.synchronize();
+    auto it = std::find_if(ptr->begin(), ptr->end(), match{name});
 
-    if(it == ptr->end()) {
+    if (it == ptr->end()) {
         return boost::none;
     }
 
@@ -191,71 +337,21 @@ struct utilization_t {
 
 execution_unit_t&
 context_t::engine() {
-    return **std::min_element(m_pool.begin(), m_pool.end(), utilization_t());
+    return **std::min_element(impl->pool.begin(), impl->pool.end(), utilization_t());
 }
 
 void
 context_t::bootstrap() {
-    COCAINE_LOG_INFO(m_log, "starting {:d} execution unit(s)", config.network.pool);
 
-    while(m_pool.size() != config.network.pool) {
-        m_pool.emplace_back(std::make_unique<execution_unit_t>(*this));
-    }
-
-    COCAINE_LOG_INFO(m_log, "starting {:d} service(s)", config.services.size());
-
-    std::vector<std::string> errored;
-
-    for(auto it = config.services.begin(); it != config.services.end(); ++it) {
-        const holder_t scoped(*m_log, {{"service", it->first}});
-
-        const auto asio = std::make_shared<asio::io_service>();
-
-        COCAINE_LOG_DEBUG(m_log, "starting service");
-
-        try {
-            insert(it->first, std::make_unique<actor_t>(*this, asio, get<api::service_t>(
-                it->second.type,
-               *this,
-               *asio,
-                it->first,
-                it->second.args
-            )));
-        } catch(const std::system_error& e) {
-            COCAINE_LOG_ERROR(m_log, "unable to initialize service: {}", error::to_string(e));
-            errored.push_back(it->first);
-        } catch(const std::exception& e) {
-            COCAINE_LOG_ERROR(m_log, "unable to initialize service: {}", e.what());
-            errored.push_back(it->first);
-        }
-    }
-
-    if(!errored.empty()) {
-        COCAINE_LOG_ERROR(m_log, "emergency core shutdown");
-
-        // Signal and stop all the services, shut down execution units.
-        terminate();
-
-        std::ostringstream stream;
-        std::ostream_iterator<char> builder(stream);
-
-        boost::spirit::karma::generate(builder, boost::spirit::karma::string % ", ", errored);
-
-        throw cocaine::error_t("couldn't start core because of %d service(s): %s",
-            errored.size(), stream.str()
-        );
-    } else {
-        m_signals.invoke<io::context::prepared>();
-    }
 }
 
 void
 context_t::terminate() {
-    COCAINE_LOG_INFO(m_log, "stopping {:d} service(s)", m_services->size());
+    COCAINE_LOG_INFO(impl->log, "stopping {:d} service(s)", impl->services->size());
 
     // Fire off to alert concerned subscribers about the shutdown. This signal happens before all
     // the outstanding connections are closed, so services have a chance to send their last wishes.
-    m_signals.invoke<context::shutdown>();
+    impl->signals.invoke<context::shutdown>();
 
     // Stop the service from accepting new clients or doing any processing. Pop them from the active
     // service list into this temporary storage, and then destroy them all at once. This is needed
@@ -263,10 +359,10 @@ context_t::terminate() {
     // lives have to be extended until those sessions are active.
     std::vector<std::unique_ptr<actor_t>> actors;
 
-    for(auto it = config.services.rbegin(); it != config.services.rend(); ++it) {
+    for (auto it = impl->config.services.rbegin(); it != impl->config.services.rend(); ++it) {
         try {
             actors.push_back(remove(it->first));
-        } catch(...) {
+        } catch (...) {
             // A service might be absent because it has failed to start during the bootstrap.
             continue;
         }
@@ -274,14 +370,16 @@ context_t::terminate() {
 
     // There should be no outstanding services left. All the extra services spawned by others, like
     // app invocation services from the node service, should be dead by now.
-    BOOST_ASSERT(m_services->empty());
+    BOOST_ASSERT(impl->services->empty());
 
-    COCAINE_LOG_INFO(m_log, "stopping {:d} execution unit(s)", m_pool.size());
+    COCAINE_LOG_INFO(impl->log, "stopping {:d} execution unit(s)", impl->pool.size());
 
-    m_pool.clear();
+    impl->pool.clear();
 
     // Destroy the service objects.
     actors.clear();
 
-    COCAINE_LOG_INFO(m_log, "core has been terminated");
+    COCAINE_LOG_INFO(impl->log, "core has been terminated");
 }
+
+} //  namespace cocaine

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -31,7 +31,7 @@
 #include "cocaine/logging.hpp"
 #include "cocaine/rpc/actor.hpp"
 
-#include <boost/optional.hpp>
+#include <boost/optional/optional.hpp>
 
 #include <boost/spirit/include/karma_char.hpp>
 #include <boost/spirit/include/karma_generate.hpp>
@@ -268,9 +268,9 @@ context_t::insert(const std::string& name, std::unique_ptr<actor_t> service) {
 
     // Fire off the signal to alert concerned subscribers about the service removal event.
     impl->signals.invoke<context::service::exposed>(actor.prototype().name(), std::forward_as_tuple(
-    actor.endpoints(),
-    actor.prototype().version(),
-    actor.prototype().root()
+        actor.endpoints(),
+        actor.prototype().version(),
+        actor.prototype().root()
     ));
 }
 
@@ -302,9 +302,9 @@ context_t::remove(const std::string& name) {
 
     // Fire off the signal to alert concerned subscribers about the service termination event.
     impl->signals.invoke<context::service::removed>(service->prototype().name(), std::forward_as_tuple(
-    nothing,
-    service->prototype().version(),
-    service->prototype().root()
+        nothing,
+        service->prototype().version(),
+        service->prototype().root()
     ));
 
     return service;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -165,44 +165,44 @@ context_t::~context_t() {
     terminate();
 }
 
-void
-context_t::listen(const std::shared_ptr<dispatch<io::context_tag>>& slot, asio::io_service& asio) {
-    impl->signals.listen(slot, asio);
-}
-
-template<class Event, class... Args>
-void
-context_t::invoke(const Args&... args) {
-    impl->signals.invoke<Event>(args...);
-}
-
-template
-void
-context_t::invoke<io::context::os_signal, int, siginfo_t>(const int&, const siginfo_t&);
-
-template
-void
-context_t::invoke<io::context::prepared>();
-
-template
-void
-context_t::invoke<io::context::shutdown>();
-
-template
-void
-context_t::invoke<io::context::service::exposed,
-                  std::string,
-                  std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>>(
-    const std::string&,
-    const std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>&);
-
-template
-void
-context_t::invoke<io::context::service::removed,
-                  std::string,
-                  std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>>(
-    const std::string&,
-    const std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>&);
+//void
+//context_t::listen(const std::shared_ptr<dispatch<io::context_tag>>& slot, asio::io_service& asio) {
+//    impl->signals.listen(slot, asio);
+//}
+//
+//template<class Event, class... Args>
+//void
+//context_t::invoke(const Args&... args) {
+//    impl->signals.invoke<Event>(args...);
+//}
+//
+//template
+//void
+//context_t::invoke<io::context::os_signal, int, siginfo_t>(const int&, const siginfo_t&);
+//
+//template
+//void
+//context_t::invoke<io::context::prepared>();
+//
+//template
+//void
+//context_t::invoke<io::context::shutdown>();
+//
+//template
+//void
+//context_t::invoke<io::context::service::exposed,
+//                  std::string,
+//                  std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>>(
+//    const std::string&,
+//    const std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>&);
+//
+//template
+//void
+//context_t::invoke<io::context::service::removed,
+//                  std::string,
+//                  std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>>(
+//    const std::string&,
+//    const std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>&);
 
 std::unique_ptr<logging::logger_t>
 context_t::log(const std::string& source) {
@@ -222,13 +222,18 @@ context_t::repository() const {
     return *impl->repository;
 }
 
+retroactive_signal<io::context_tag>&
+context_t::signal_hub() {
+    return impl->signals;
+}
+
 const config_t&
 context_t::config() const {
     return impl->config;
 }
 
 port_mapping_t&
-context_t::mapper() const {
+context_t::mapper(){
     return impl->mapper;
 }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -46,197 +46,6 @@
 
 namespace cocaine {
 
-using namespace cocaine::io;
-
-using blackhole::scope::holder_t;
-
-struct context_t::impl_t {
-    impl_t(config_t _config, std::unique_ptr<logging::logger_t> _log) :
-        log(std::move(_log)),
-        config(_config),
-        mapper(config)
-    {}
-    typedef std::deque<std::pair<std::string, std::unique_ptr<actor_t>>> service_list_t;
-
-    // TODO: There was an idea to use the Repository to enable pluggable sinks and whatever else for
-    // for the Blackhole, when all the common stuff is extracted to a separate library.
-    std::unique_ptr<logging::logger_t> log;
-
-    // NOTE: This is the first object in the component tree, all the other dynamic components, be it
-    // storages or isolates, have to be declared after this one.
-    std::unique_ptr<api::repository_t> repository;
-
-    // A pool of execution units - threads responsible for doing all the service invocations.
-    std::vector<std::unique_ptr<execution_unit_t>> pool;
-
-    // Services are stored as a vector of pairs to preserve the initialization order. Synchronized,
-    // because services are allowed to start and stop other services during their lifetime.
-    synchronized<service_list_t> services;
-
-    // Context signalling hub.
-    retroactive_signal<io::context_tag> signals;
-
-    const config_t config;
-
-    // Service port mapping and pinning.
-    port_mapping_t mapper;
-
-};
-
-void
-context_t::impl_deleter_t::operator()(impl_t* ptr) const {
-    delete ptr;
-}
-
-
-context_t::context_t(config_t config, std::unique_ptr<logging::logger_t> logger) :
-    impl(new impl_t(std::move(config), std::move(logger))) {
-
-    const holder_t scoped(*impl->log, {{"source", "core"}});
-
-    COCAINE_LOG_INFO(impl->log, "initializing the core");
-
-    impl->repository = std::make_unique<api::repository_t>(log("repository"));
-
-    // Load the builtin plugins.
-    essentials::initialize(*impl->repository);
-
-    // Load the rest of plugins.
-    impl->repository->load(impl->config.path.plugins);
-
-    // Spin up all the configured services, launch execution units.
-    COCAINE_LOG_INFO(impl->log, "starting {:d} execution unit(s)", config.network.pool);
-
-    while (impl->pool.size() != config.network.pool) {
-        impl->pool.emplace_back(std::make_unique<execution_unit_t>(*this));
-    }
-
-    COCAINE_LOG_INFO(impl->log, "starting {:d} service(s)", config.services.size());
-
-    std::vector<std::string> errored;
-
-    for (auto it = config.services.begin(); it != config.services.end(); ++it) {
-        const holder_t scoped(*impl->log, {{"service", it->first}});
-
-        const auto asio = std::make_shared<asio::io_service>();
-
-        COCAINE_LOG_DEBUG(impl->log, "starting service");
-
-        try {
-            insert(it->first, std::make_unique<actor_t>(*this, asio, repository().get<api::service_t>(
-            it->second.type,
-            *this,
-            *asio,
-            it->first,
-            it->second.args
-            )));
-        } catch (const std::system_error& e) {
-            COCAINE_LOG_ERROR(impl->log, "unable to initialize service: {}", error::to_string(e));
-            errored.push_back(it->first);
-        } catch (const std::exception& e) {
-            COCAINE_LOG_ERROR(impl->log, "unable to initialize service: {}", e.what());
-            errored.push_back(it->first);
-        }
-    }
-
-    if (!errored.empty()) {
-        COCAINE_LOG_ERROR(impl->log, "emergency core shutdown");
-
-        // Signal and stop all the services, shut down execution units.
-        terminate();
-
-        std::ostringstream stream;
-        std::ostream_iterator<char> builder(stream);
-
-        boost::spirit::karma::generate(builder, boost::spirit::karma::string % ", ", errored);
-
-        throw cocaine::error_t("couldn't start core because of %d service(s): %s",
-                               errored.size(), stream.str()
-        );
-    } else {
-        impl->signals.invoke<io::context::prepared>();
-    }
-}
-
-context_t::~context_t() {
-    const holder_t scoped(*impl->log, {{"source", "core"}});
-
-    // Signal and stop all the services, shut down execution units.
-    terminate();
-}
-
-//void
-//context_t::listen(const std::shared_ptr<dispatch<io::context_tag>>& slot, asio::io_service& asio) {
-//    impl->signals.listen(slot, asio);
-//}
-//
-//template<class Event, class... Args>
-//void
-//context_t::invoke(const Args&... args) {
-//    impl->signals.invoke<Event>(args...);
-//}
-//
-//template
-//void
-//context_t::invoke<io::context::os_signal, int, siginfo_t>(const int&, const siginfo_t&);
-//
-//template
-//void
-//context_t::invoke<io::context::prepared>();
-//
-//template
-//void
-//context_t::invoke<io::context::shutdown>();
-//
-//template
-//void
-//context_t::invoke<io::context::service::exposed,
-//                  std::string,
-//                  std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>>(
-//    const std::string&,
-//    const std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>&);
-//
-//template
-//void
-//context_t::invoke<io::context::service::removed,
-//                  std::string,
-//                  std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>>(
-//    const std::string&,
-//    const std::tuple<std::vector<asio::ip::tcp::endpoint>, unsigned int, io::graph_root_t>&);
-
-std::unique_ptr<logging::logger_t>
-context_t::log(const std::string& source) {
-    return log(source, {});
-}
-
-std::unique_ptr<logging::logger_t>
-context_t::log(const std::string& source, blackhole::attributes_t attributes) {
-    attributes.push_back({"source", {source}});
-
-    // TODO: Make it possible to use in-place operator+= to fill in more attributes?
-    return std::make_unique<blackhole::wrapper_t>(*impl->log, std::move(attributes));
-}
-
-const api::repository_t&
-context_t::repository() const {
-    return *impl->repository;
-}
-
-retroactive_signal<io::context_tag>&
-context_t::signal_hub() {
-    return impl->signals;
-}
-
-const config_t&
-context_t::config() const {
-    return impl->config;
-}
-
-port_mapping_t&
-context_t::mapper(){
-    return impl->mapper;
-}
-
 namespace {
 
 struct match {
@@ -249,142 +58,280 @@ struct match {
     const std::string& name;
 };
 
-} // namespace
+}
 
-void
-context_t::insert(const std::string& name, std::unique_ptr<actor_t> service) {
-    const holder_t scoped(*impl->log, {{"source", "core"}});
+using namespace cocaine::io;
 
-    const actor_t& actor = *service;
+using blackhole::scope::holder_t;
 
-    impl->services.apply([&](impl_t::service_list_t& list) {
-        if (std::count_if(list.begin(), list.end(), match{name})) {
-            throw cocaine::error_t("service '%s' already exists", name);
+class context_impl_t : public context_t {
+public:
+    typedef std::pair<std::string, std::unique_ptr<actor_t>> service_desc_t;
+    typedef std::deque<service_desc_t> service_list_t;
+
+    context_impl_t(config_t _config, std::unique_ptr<logging::logger_t> _log) :
+        m_log(std::move(_log)),
+        m_config(_config),
+        m_mapper(m_config)
+    {
+        const holder_t scoped(*m_log, {{"source", "core"}});
+
+        COCAINE_LOG_INFO(m_log, "initializing the core");
+
+        m_repository = std::make_unique<api::repository_t>(log("repository"));
+
+        // Load the builtin plugins.
+        essentials::initialize(*m_repository);
+
+        // Load the rest of plugins.
+        m_repository->load(m_config.path.plugins);
+
+        // Spin up all the configured services, launch execution units.
+        COCAINE_LOG_INFO(m_log, "starting {:d} execution unit(s)", m_config.network.pool);
+
+        while (m_pool.size() != m_config.network.pool) {
+            m_pool.emplace_back(std::make_unique<execution_unit_t>(*this));
         }
 
-        service->run();
+        COCAINE_LOG_INFO(m_log, "starting {:d} service(s)", m_config.services.size());
 
-        COCAINE_LOG_DEBUG(impl->log, "service has been started", {
-            { "service", { name }}
+        std::vector<std::string> errored;
+
+        for (auto it = m_config.services.begin(); it != m_config.services.end(); ++it) {
+            const holder_t scoped(*m_log, {{"service", it->first}});
+
+            const auto asio = std::make_shared<asio::io_service>();
+
+            COCAINE_LOG_DEBUG(m_log, "starting service");
+
+            try {
+                insert(it->first, std::make_unique<actor_t>(*this, asio, repository().get<api::service_t>(
+                    it->second.type,
+                    *this,
+                    *asio,
+                    it->first,
+                    it->second.args
+                )));
+            } catch (const std::system_error& e) {
+                COCAINE_LOG_ERROR(m_log, "unable to initialize service: {}", error::to_string(e));
+                errored.push_back(it->first);
+            } catch (const std::exception& e) {
+                COCAINE_LOG_ERROR(m_log, "unable to initialize service: {}", e.what());
+                errored.push_back(it->first);
+            }
+        }
+
+        if (!errored.empty()) {
+            COCAINE_LOG_ERROR(m_log, "emergency core shutdown");
+
+            // Signal and stop all the services, shut down execution units.
+            terminate();
+
+            std::ostringstream stream;
+            std::ostream_iterator<char> builder(stream);
+
+            boost::spirit::karma::generate(builder, boost::spirit::karma::string % ", ", errored);
+
+            throw cocaine::error_t("couldn't start core because of %d service(s): %s",
+                                   errored.size(), stream.str()
+            );
+        } else {
+            m_signals.invoke<io::context::prepared>();
+        }
+    }
+
+    ~context_impl_t() {
+        const holder_t scoped(*m_log, {{"source", "core"}});
+
+        // Signal and stop all the services, shut down execution units.
+        terminate();
+    }
+
+    std::unique_ptr<logging::logger_t>
+    log(const std::string& source) {
+        return log(source, {});
+    }
+
+    std::unique_ptr<logging::logger_t>
+    log(const std::string& source, blackhole::attributes_t attributes) {
+        attributes.push_back({"source", {source}});
+
+        // TODO: Make it possible to use in-place operator+= to fill in more attributes?
+        return std::make_unique<blackhole::wrapper_t>(*m_log, std::move(attributes));
+    }
+
+    const api::repository_t&
+    repository() const {
+        return *m_repository;
+    }
+
+    retroactive_signal<io::context_tag>&
+    signal_hub() {
+        return m_signals;
+    }
+
+    const config_t&
+    config() const {
+        return m_config;
+    }
+
+    port_mapping_t&
+    mapper(){
+        return m_mapper;
+    }
+
+    void
+    insert(const std::string& name, std::unique_ptr<actor_t> service) {
+        const holder_t scoped(*m_log, {{"source", "core"}});
+
+        const actor_t& actor = *service;
+
+        m_services.apply([&](service_list_t& list) {
+            auto it = std::find_if(list.begin(), list.end(), match{name});
+            if(it != list.end()) {
+                throw cocaine::error_t("service '%s' already exists", name);
+            }
+
+            service->run();
+
+            COCAINE_LOG_DEBUG(m_log, "service has been started", {
+                { "service", { name }}
+            });
+
+            list.emplace_back(name, std::move(service));
         });
 
-        list.emplace_back(name, std::move(service));
-    });
+        // Fire off the signal to alert concerned subscribers about the service removal event.
+        m_signals.invoke<context::service::exposed>(actor.prototype().name(), std::forward_as_tuple(
+            actor.endpoints(),
+            actor.prototype().version(),
+            actor.prototype().root()
+        ));
+    }
 
-    // Fire off the signal to alert concerned subscribers about the service removal event.
-    impl->signals.invoke<context::service::exposed>(actor.prototype().name(), std::forward_as_tuple(
-        actor.endpoints(),
-        actor.prototype().version(),
-        actor.prototype().root()
-    ));
-}
+    std::unique_ptr<actor_t>
+    remove(const std::string& name) {
+        const holder_t scoped(*m_log, {{"source", "core"}});
 
-std::unique_ptr<actor_t>
-context_t::remove(const std::string& name) {
-    const holder_t scoped(*impl->log, {{"source", "core"}});
+        std::unique_ptr<actor_t> service;
 
-    std::unique_ptr<actor_t> service;
+        m_services.apply([&](service_list_t& list) {
+            auto it = std::find_if(list.begin(), list.end(), match{name});
+            if(it != list.end()) {
+                service = std::move(it->second);
+                list.erase(it);
+            } else {
+                throw cocaine::error_t("service '%s' doesn't exist", name);
+            }
+        });
 
-    impl->services.apply([&](impl_t::service_list_t& list) {
-        auto it = std::find_if(list.begin(), list.end(), match{name});
+        service->terminate();
 
-        if (it == list.end()) {
-            throw cocaine::error_t("service '%s' doesn't exist", name);
+        COCAINE_LOG_DEBUG(m_log, "service has been stopped", {
+            { "service", name }
+        });
+
+        // Service is already terminated, so there's no reason to try to get its endpoints.
+        std::vector<asio::ip::tcp::endpoint> nothing;
+
+        // Fire off the signal to alert concerned subscribers about the service termination event.
+        m_signals.invoke<context::service::removed>(service->prototype().name(), std::forward_as_tuple(
+            nothing,
+            service->prototype().version(),
+            service->prototype().root()
+        ));
+
+        return service;
+    }
+
+    boost::optional<const actor_t&>
+    locate(const std::string& name) const {
+        return m_services.apply([&](const service_list_t& list) -> boost::optional<const actor_t&> {
+            auto it = std::find_if(list.begin(), list.end(), match{name});
+            if (it == list.end()) {
+                return boost::none;
+            }
+
+            return boost::optional<const actor_t&>(it->second->is_active(), *it->second);
+        });
+    }
+
+    execution_unit_t&
+    engine() {
+        typedef std::unique_ptr<execution_unit_t> unit_t;
+        auto comp = [](const unit_t& lhs, const unit_t& rhs) {
+            return lhs->utilization() < rhs->utilization();
+        };
+        return **std::min_element(m_pool.begin(), m_pool.end(), comp);
+    }
+
+    void
+    terminate() {
+        COCAINE_LOG_INFO(m_log, "stopping {:d} service(s)", m_services->size());
+
+        // Fire off to alert concerned subscribers about the shutdown. This signal happens before all
+        // the outstanding connections are closed, so services have a chance to send their last wishes.
+        m_signals.invoke<context::shutdown>();
+
+        // Stop the service from accepting new clients or doing any processing. Pop them from the active
+        // service list into this temporary storage, and then destroy them all at once. This is needed
+        // because sessions in the execution units might still have references to the services, and their
+        // lives have to be extended until those sessions are active.
+        std::vector<std::unique_ptr<actor_t>> actors;
+
+        for (auto it = m_config.services.rbegin(); it != m_config.services.rend(); ++it) {
+            try {
+                actors.push_back(remove(it->first));
+            } catch (...) {
+                // A service might be absent because it has failed to start during the bootstrap.
+                continue;
+            }
         }
 
-        service = std::move(it->second);
-        list.erase(it);
-    });
+        // There should be no outstanding services left. All the extra services spawned by others, like
+        // app invocation services from the node service, should be dead by now.
+        BOOST_ASSERT(m_services->empty());
 
-    service->terminate();
+        COCAINE_LOG_INFO(m_log, "stopping {:d} execution unit(s)", m_pool.size());
 
-    COCAINE_LOG_DEBUG(impl->log, "service has been stopped", {
-        { "service", name }
-    });
+        m_pool.clear();
 
-    // Service is already terminated, so there's no reason to try to get its endpoints.
-    std::vector<asio::ip::tcp::endpoint> nothing;
+        // Destroy the service objects.
+        actors.clear();
 
-    // Fire off the signal to alert concerned subscribers about the service termination event.
-    impl->signals.invoke<context::service::removed>(service->prototype().name(), std::forward_as_tuple(
-        nothing,
-        service->prototype().version(),
-        service->prototype().root()
-    ));
-
-    return service;
-}
-
-boost::optional<const actor_t&>
-context_t::locate(const std::string& name) const {
-    auto ptr = impl->services.synchronize();
-    auto it = std::find_if(ptr->begin(), ptr->end(), match{name});
-
-    if (it == ptr->end()) {
-        return boost::none;
+        COCAINE_LOG_INFO(m_log, "core has been terminated");
     }
 
-    return boost::optional<const actor_t&>(it->second->is_active(), *it->second);
-}
+private:
+    // TODO: There was an idea to use the Repository to enable pluggable sinks and whatever else for
+    // for the Blackhole, when all the common stuff is extracted to a separate library.
+    std::unique_ptr<logging::logger_t> m_log;
 
-namespace {
+    // NOTE: This is the first object in the component tree, all the other dynamic components, be it
+    // storages or isolates, have to be declared after this one.
+    std::unique_ptr<api::repository_t> m_repository;
 
-struct utilization_t {
-    typedef std::unique_ptr<execution_unit_t> value_type;
+    // A pool of execution units - threads responsible for doing all the service invocations.
+    std::vector<std::unique_ptr<execution_unit_t>> m_pool;
 
-    bool
-    operator()(const value_type& lhs, const value_type& rhs) const {
-        return lhs->utilization() < rhs->utilization();
-    }
+    // Services are stored as a vector of pairs to preserve the initialization order. Synchronized,
+    // because services are allowed to start and stop other services during their lifetime.
+    synchronized<service_list_t> m_services;
+
+    // Context signalling hub.
+    retroactive_signal<io::context_tag> m_signals;
+
+    const config_t m_config;
+
+    // Service port mapping and pinning.
+    port_mapping_t m_mapper;
+
 };
 
-} // namespace
-
-execution_unit_t&
-context_t::engine() {
-    return **std::min_element(impl->pool.begin(), impl->pool.end(), utilization_t());
+std::unique_ptr<context_t>
+get_context(config_t config, std::unique_ptr<logging::logger_t> log) {
+    return std::unique_ptr<context_t>(new context_impl_t(std::move(config), std::move(log)));
 }
 
-void
-context_t::bootstrap() {
-
-}
-
-void
-context_t::terminate() {
-    COCAINE_LOG_INFO(impl->log, "stopping {:d} service(s)", impl->services->size());
-
-    // Fire off to alert concerned subscribers about the shutdown. This signal happens before all
-    // the outstanding connections are closed, so services have a chance to send their last wishes.
-    impl->signals.invoke<context::shutdown>();
-
-    // Stop the service from accepting new clients or doing any processing. Pop them from the active
-    // service list into this temporary storage, and then destroy them all at once. This is needed
-    // because sessions in the execution units might still have references to the services, and their
-    // lives have to be extended until those sessions are active.
-    std::vector<std::unique_ptr<actor_t>> actors;
-
-    for (auto it = impl->config.services.rbegin(); it != impl->config.services.rend(); ++it) {
-        try {
-            actors.push_back(remove(it->first));
-        } catch (...) {
-            // A service might be absent because it has failed to start during the bootstrap.
-            continue;
-        }
-    }
-
-    // There should be no outstanding services left. All the extra services spawned by others, like
-    // app invocation services from the node service, should be dead by now.
-    BOOST_ASSERT(impl->services->empty());
-
-    COCAINE_LOG_INFO(impl->log, "stopping {:d} execution unit(s)", impl->pool.size());
-
-    impl->pool.clear();
-
-    // Destroy the service objects.
-    actors.clear();
-
-    COCAINE_LOG_INFO(impl->log, "core has been terminated");
-}
 
 } //  namespace cocaine

--- a/src/context/config.cpp
+++ b/src/context/config.cpp
@@ -19,8 +19,8 @@
 */
 
 #include "cocaine/context/config.hpp"
-
 #include "cocaine/defaults.hpp"
+#include "cocaine/errors.hpp"
 
 #include <asio/io_service.hpp>
 #include <asio/ip/host_name.hpp>

--- a/src/context/mapper.cpp
+++ b/src/context/mapper.cpp
@@ -21,7 +21,9 @@
 #include "cocaine/context/mapper.hpp"
 
 #include "cocaine/context/config.hpp"
+#include "cocaine/errors.hpp"
 
+#include <map>
 #include <numeric>
 #include <random>
 

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -1,0 +1,113 @@
+/*
+    Copyright (c) 2011-2014 Andrey Sibiryov <me@kobology.ru>
+    Copyright (c) 2011-2014 Other contributors as noted in the AUTHORS file.
+
+    This file is part of Cocaine.
+
+    Cocaine is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Cocaine is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "cocaine/rpc/asio/decoder.hpp"
+
+#include "cocaine/errors.hpp"
+#include "cocaine/hpack/header.hpp"
+#include "cocaine/hpack/msgpack_traits.hpp"
+
+#include <msgpack.hpp>
+
+#include <boost/optional/optional.hpp>
+#include <boost/range/algorithm/find_if.hpp>
+
+namespace cocaine {
+namespace io {
+
+
+namespace aux {
+
+
+auto
+decoded_message_t::span() const -> uint64_t {
+    return object.via.array.ptr[0].as<uint64_t>();
+}
+
+auto
+decoded_message_t::type() const -> uint64_t {
+    return object.via.array.ptr[1].as<uint64_t>();
+}
+
+auto
+decoded_message_t::args() const -> const msgpack::object& {
+    return object.via.array.ptr[2];
+}
+
+auto
+decoded_message_t::meta() const -> const std::vector<hpack::header_t>& {
+    return metadata;
+}
+
+auto
+decoded_message_t::meta(const hpack::header::data_t& name) const -> boost::optional<hpack::header_t> {
+    auto it = boost::find_if(metadata, [&](const hpack::header_t& element) -> bool {
+        return element.get_name() == name;
+    });
+
+    return it == metadata.end() ? boost::none : boost::make_optional(*it);
+}
+
+void
+decoded_message_t::clear() {
+    metadata.clear();
+}
+
+} // namespace aux
+
+
+size_t
+decoder_t::decode(const char* data, size_t size, message_type& message, std::error_code& ec) {
+    size_t offset = 0;
+
+    // NOTE: We have to clear msgpack zone every decoding iteration to prevent memory leaking
+    // for objects structure, because they have no way to notify about self-destruction. Hope
+    // someday we migrate to v1.* and everything will be fine automatically.
+    zone.clear();
+
+    msgpack::unpack_return rv = msgpack::unpack(data, size, &offset, &zone, &message.object);
+
+    if(rv == msgpack::UNPACK_SUCCESS || rv == msgpack::UNPACK_EXTRA_BYTES) {
+        if(message.object.type != msgpack::type::ARRAY || message.object.via.array.size < 3) {
+            ec = error::frame_format_error;
+        } else if(message.object.via.array.ptr[0].type != msgpack::type::POSITIVE_INTEGER ||
+                  message.object.via.array.ptr[1].type != msgpack::type::POSITIVE_INTEGER ||
+                  message.object.via.array.ptr[2].type != msgpack::type::ARRAY)
+        {
+            ec = error::frame_format_error;
+        } else if(message.object.via.array.size > 3) {
+            if(message.object.via.array.ptr[3].type != msgpack::type::ARRAY) {
+                ec = error::frame_format_error;
+            } else if(!hpack::msgpack_traits::unpack_vector(
+            message.object.via.array.ptr[3], hpack_context, message.metadata))
+            {
+                ec = error::hpack_error;
+            }
+        }
+    } else if(rv == msgpack::UNPACK_CONTINUE) {
+        ec = error::insufficient_bytes;
+    } else if(rv == msgpack::UNPACK_PARSE_ERROR) {
+        ec = error::parse_error;
+    }
+
+    return offset;
+}
+
+}} // namespace cocaine::io

--- a/src/dispatch.cpp
+++ b/src/dispatch.cpp
@@ -20,6 +20,8 @@
 
 #include "cocaine/rpc/dispatch.hpp"
 
+#include "cocaine/errors.hpp"
+
 using namespace cocaine::io;
 
 basic_dispatch_t::basic_dispatch_t(const std::string& name):

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -1,0 +1,99 @@
+/*
+    Copyright (c) 2011-2014 Andrey Sibiryov <me@kobology.ru>
+    Copyright (c) 2011-2016 Other contributors as noted in the AUTHORS file.
+
+    This file is part of Cocaine.
+
+    Cocaine is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Cocaine is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "cocaine/rpc/asio/encoder.hpp"
+
+#include "cocaine/errors.hpp"
+
+#include "cocaine/hpack/header.hpp"
+#include "cocaine/hpack/msgpack_traits.hpp"
+
+#include "cocaine/memory.hpp"
+
+#include "cocaine/rpc/protocol.hpp"
+
+#include "cocaine/trace/trace.hpp"
+
+#include "cocaine/traits.hpp"
+#include "cocaine/traits/tuple.hpp"
+
+#include <cstring>
+
+namespace cocaine {
+namespace io {
+
+namespace aux {
+
+encoded_buffers_t::encoded_buffers_t() :
+offset(0) {
+    vector.resize(kInitialBufferSize);
+}
+
+void
+encoded_buffers_t::write(const char* data, size_t size) {
+    while (size > vector.size() - offset) {
+        vector.resize(vector.size() * 2);
+    }
+
+    std::memcpy(vector.data() + offset, data, size);
+
+    offset += size;
+}
+
+
+auto
+encoded_message_t::data() const -> const char* {
+    return buffer.vector.data();
+}
+
+size_t
+encoded_message_t::size() const {
+    return buffer.offset;
+}
+
+unbound_message_t::unbound_message_t(function_type&& bind_): bind(std::move(bind_)) { }
+
+} //  namespace aux
+
+void
+encoder_t::pack_headers(packer_type& packer, const hpack::header_storage_t& headers) {
+    packer.pack_array(3);
+
+    uint64_t trace_id  = trace_t::current().get_trace_id();
+    uint64_t span_id   = trace_t::current().get_id();
+    uint64_t parent_id = trace_t::current().get_parent_id();
+
+    hpack::msgpack_traits::pack<hpack::headers::trace_id<>>(packer, hpack_context, hpack::header::create_data(trace_id));
+    hpack::msgpack_traits::pack<hpack::headers::span_id<>>(packer, hpack_context, hpack::header::create_data(span_id));
+    hpack::msgpack_traits::pack<hpack::headers::parent_id<>>(packer, hpack_context, hpack::header::create_data(parent_id));
+
+    for (const auto& header: headers.get_headers()) {
+        // TODO: maybe we need a runtime check not to pack headers twice
+        hpack::msgpack_traits::pack(packer, hpack_context, header);
+    }
+}
+
+aux::encoded_message_t
+encoder_t::encode(const message_type& message) {
+    return message.bind(*this);
+}
+
+}} // namespace cocaine::io
+

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -26,10 +26,13 @@
 #include "cocaine/detail/chamber.hpp"
 
 #include "cocaine/rpc/asio/transport.hpp"
+#include "cocaine/rpc/dispatch.hpp"
 #include "cocaine/rpc/session.hpp"
 
 #include <blackhole/logger.hpp>
 #include <blackhole/wrapper.hpp>
+
+#include <boost/lexical_cast.hpp>
 
 #include <asio/io_service.hpp>
 #include <asio/ip/tcp.hpp>

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -20,6 +20,9 @@
 
 #include "cocaine/hpack/header.h"
 #include "cocaine/hpack/header.hpp"
+#include "cocaine/hpack/static_table.hpp"
+
+#include <cassert>
 
 namespace cocaine { namespace hpack {
 

--- a/src/runtime/pid_file.cpp
+++ b/src/runtime/pid_file.cpp
@@ -19,6 +19,7 @@
 */
 
 #include "cocaine/detail/runtime/pid_file.hpp"
+#include "cocaine/errors.hpp"
 
 #include <csignal>
 

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -21,6 +21,7 @@
 #include "cocaine/common.hpp"
 #include "cocaine/context.hpp"
 #include "cocaine/context/config.hpp"
+#include "cocaine/context/signal.hpp"
 #include "cocaine/errors.hpp"
 #include "cocaine/idl/context.hpp"
 #include "cocaine/signal.hpp"
@@ -114,7 +115,7 @@ struct sighup_handler_t {
 
         logger = std::move(log);
 
-        context.invoke<cocaine::io::context::os_signal>(signum, info);
+        context.signal_hub().invoke<cocaine::io::context::os_signal>(signum, info);
         sig_handler.async_wait(SIGHUP, *this);
     }
 };
@@ -128,7 +129,7 @@ struct sigchild_handler_t {
             return;
         }
         assert(!ec);
-        context.invoke<cocaine::io::context::os_signal>(signum, info);
+        context.signal_hub().invoke<cocaine::io::context::os_signal>(signum, info);
         handler.async_wait(signum, *this);
     }
 };

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -308,7 +308,7 @@ main(int argc, char* argv[]) {
     // Run context
     std::unique_ptr<context_t> context;
     try {
-        context.reset(new context_t(*config, std::move(logger)));
+        context = get_context(*config, std::move(logger));
     } catch(const std::system_error& e) {
         COCAINE_LOG_ERROR(root, "unable to initialize the context - {}.", error::to_string(e));
         signal_handler.stop();

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -20,6 +20,9 @@
 
 #include "cocaine/common.hpp"
 #include "cocaine/context.hpp"
+#include "cocaine/context/config.hpp"
+#include "cocaine/errors.hpp"
+#include "cocaine/idl/context.hpp"
 #include "cocaine/signal.hpp"
 
 #include "cocaine/detail/runtime/logging.hpp"
@@ -98,13 +101,13 @@ struct sighup_handler_t {
 
         COCAINE_LOG_INFO(wrapper, "resetting logger");
         std::stringstream stream;
-        stream << boost::lexical_cast<std::string>(context.config.logging.loggers);
+        stream << boost::lexical_cast<std::string>(context.config().logging.loggers);
 
         // Create a new logger and set the filter before swap to be sure that no events are missed.
         auto log = registry.builder<blackhole::config::json_t>(stream)
             .build("core");
 
-        const auto severity = context.config.logging.severity;
+        const auto severity = context.config().logging.severity;
         log.filter([=](const blackhole::record_t& record) -> bool {
             return record.severity() >= severity || !trace_t::current().empty();
         });

--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -25,6 +25,7 @@
 #include "cocaine/api/storage.hpp"
 
 #include "cocaine/context.hpp"
+#include "cocaine/context/signal.hpp"
 #include "cocaine/dynamic.hpp"
 #include "cocaine/engine.hpp"
 
@@ -403,7 +404,7 @@ locator_t::locator_t(context_t& context, io_service& asio, const std::string& na
         throw std::system_error(e.code(), "unable to initialize routing groups");
     }
 
-    context.listen(m_signals, asio);
+    context.signal_hub().listen(m_signals, asio);
 }
 
 locator_t::~locator_t() {

--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -25,7 +25,7 @@
 #include "cocaine/api/storage.hpp"
 
 #include "cocaine/context.hpp"
-
+#include "cocaine/dynamic.hpp"
 #include "cocaine/engine.hpp"
 
 #include "cocaine/idl/primitive.hpp"
@@ -380,7 +380,7 @@ locator_t::locator_t(context_t& context, io_service& asio, const std::string& na
         m_signals->on<context::service::removed>(std::bind(&locator_t::on_service, this,
             ph::_1, ph::_2, modes::removed));
 
-        m_cluster = m_context.get<api::cluster_t>(type, m_context, *this, name + ":cluster", args);
+        m_cluster = m_context.repository().get<api::cluster_t>(type, m_context, *this, name + ":cluster", args);
     }
 
     if(root.as_object().count("gateway")) {
@@ -390,7 +390,7 @@ locator_t::locator_t(context_t& context, io_service& asio, const std::string& na
 
         COCAINE_LOG_INFO(m_log, "using '{}' as a gateway manager, enabling service routing", type);
 
-        m_gateway = m_context.get<api::gateway_t>(type, m_context, name + ":gateway", args);
+        m_gateway = m_context.repository().get<api::gateway_t>(type, m_context, name + ":gateway", args);
     }
 
     // It's here to keep the reference alive.

--- a/src/service/locator/routing.cpp
+++ b/src/service/locator/routing.cpp
@@ -19,7 +19,7 @@
 */
 
 #include "cocaine/detail/service/locator/routing.hpp"
-
+#include "cocaine/errors.hpp"
 #include "cocaine/logging.hpp"
 
 #include <math.h>

--- a/src/service/logging.cpp
+++ b/src/service/logging.cpp
@@ -87,8 +87,9 @@ logging_t::logging_t(context_t& context, asio::io_service& asio, const std::stri
             auto log = registry.builder<blackhole::config::json_t>(stream)
                 .build(backend);
 
-            log.filter([&](const blackhole::record_t& record) -> bool {
-                return record.severity() >= context.config().logging.severity || !trace_t::current().empty();
+            auto severity = context.config().logging.severity;
+            log.filter([=](const blackhole::record_t& record) -> bool {
+                return record.severity() >= severity || !trace_t::current().empty();
             });
 
             logger.reset(new blackhole::root_logger_t(std::move(log)));

--- a/src/service/logging.cpp
+++ b/src/service/logging.cpp
@@ -41,6 +41,8 @@
 #include <blackhole/wrapper.hpp>
 
 #include "cocaine/context.hpp"
+#include "cocaine/context/config.hpp"
+#include "cocaine/dynamic.hpp"
 #include "cocaine/logging.hpp"
 #include "cocaine/traits/attributes.hpp"
 #include "cocaine/traits/enum.hpp"
@@ -80,13 +82,13 @@ logging_t::logging_t(context_t& context, asio::io_service& asio, const std::stri
             registry.add<blackhole::sink::socket::udp_t>();
 
             std::stringstream stream;
-            stream << boost::lexical_cast<std::string>(context.config.logging.loggers);
+            stream << boost::lexical_cast<std::string>(context.config().logging.loggers);
 
             auto log = registry.builder<blackhole::config::json_t>(stream)
                 .build(backend);
 
             log.filter([&](const blackhole::record_t& record) -> bool {
-                return record.severity() >= context.config.logging.severity || !trace_t::current().empty();
+                return record.severity() >= context.config().logging.severity || !trace_t::current().empty();
             });
 
             logger.reset(new blackhole::root_logger_t(std::move(log)));

--- a/src/service/logging.cpp
+++ b/src/service/logging.cpp
@@ -42,6 +42,7 @@
 
 #include "cocaine/context.hpp"
 #include "cocaine/context/config.hpp"
+#include "cocaine/context/signal.hpp"
 #include "cocaine/dynamic.hpp"
 #include "cocaine/logging.hpp"
 #include "cocaine/traits/attributes.hpp"
@@ -100,7 +101,7 @@ logging_t::logging_t(context_t& context, asio::io_service& asio, const std::stri
                 reset_logger_fn();
             }
         });
-        context.listen(signals, asio);
+        context.signal_hub().listen(signals, asio);
     }
 
     on<io::log::emit>(std::bind(&logging_t::on_emit, this, ph::_1, ph::_2, ph::_3, ph::_4));

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -20,6 +20,7 @@
 
 #include "cocaine/rpc/session.hpp"
 
+#include "cocaine/hpack/static_table.hpp"
 #include "cocaine/logging.hpp"
 
 #include "cocaine/rpc/asio/transport.hpp"

--- a/src/storage/files.cpp
+++ b/src/storage/files.cpp
@@ -21,6 +21,7 @@
 #include "cocaine/detail/storage/files.hpp"
 
 #include "cocaine/context.hpp"
+#include "cocaine/dynamic.hpp"
 #include "cocaine/logging.hpp"
 
 #include <numeric>
@@ -198,12 +199,7 @@ files_t::find(const std::string& collection, const std::vector<std::string>& tag
         fs::directory_iterator it(store_path / *tag), end;
 
         while(it != end) {
-#if BOOST_VERSION >= 104600
-            const std::string object = it->path().filename().string();
-#else
-            const std::string object = it->path().filename();
-#endif
-
+            const std::string object = it->path().filename().native();
             if(!fs::exists(*it)) {
                 COCAINE_LOG_DEBUG(m_log, "purging object '{}' from tag '{}'", object, *tag);
 

--- a/src/unique_id.cpp
+++ b/src/unique_id.cpp
@@ -20,7 +20,11 @@
 
 #include "cocaine/unique_id.hpp"
 
+#include "cocaine/errors.hpp"
+
 #include <uuid/uuid.h>
+
+#include <string>
 
 using namespace cocaine;
 


### PR DESCRIPTION
Some refactor against context_t:
  * context_t is pimpl now
  * get rid of template methods or use explicit template instantiation
  * include optimization
This refactor gives about 10% boost in compilation time.
I have some more changes planned, but let's decide if we need to split it to several PR or not.