### PR TITLE
refactor(errors): use well defined algo for hashing instead of std::hash

### DIFF
--- a/include/cocaine/errors.hpp
+++ b/include/cocaine/errors.hpp
@@ -108,6 +108,10 @@ struct registrar {
     auto
     add(const std::error_category& ec) -> size_t;
 
+    static
+    auto
+    add(const std::error_category& ec, size_t index) -> void;
+
 private:
     struct impl_type;
 

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -357,10 +357,14 @@ std::unique_ptr<registrar::impl_type> registrar::ptr(std::make_unique<impl_type>
 auto
 registrar::add(const std::error_category& ec) -> size_t {
     size_t index = hash(ec.name()) | 0xFF;
-    return ptr->mapping.apply([&](impl_type::mapping_t& mapping){
-        if(mapping.insert({index, &ec}).second) {
-            return index;
-        } else {
+    add(ec, index);
+    return index;
+}
+
+auto
+registrar::add(const std::error_category& ec, size_t index) -> void {
+    ptr->mapping.apply([&](impl_type::mapping_t& mapping){
+        if(!mapping.insert({index, &ec}).second) {
             throw error_t("duplicate error category");
         }
     });

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -312,8 +312,6 @@ registrar::impl_type {
 
     synchronized<mapping_t> mapping;
 
-    // Dynamic error category name-based hash.
-    std::hash<std::string> hash;
 
     impl_type();
 };

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -27,10 +27,28 @@
 #include <boost/assign/list_of.hpp>
 #include <boost/bimap.hpp>
 
+#define PROTOTYPES
+#include <mutils/mincludes.h>
+#include <mutils/mhash.h>
+
 using namespace cocaine;
 using namespace cocaine::error;
 
 namespace {
+
+size_t hash(const std::string& data) {
+    unsigned char digest[16] = {};
+    MHASH thread = mhash_init(MHASH_MD5);
+    mhash(thread, data.data(), data.size());
+    mhash_deinit(thread, digest);
+    size_t result = digest[0];
+    // This is requred because of endiannes
+    for(size_t i = 1; i < 8; i++) {
+        result <<= 8;
+        result += digest[i];
+    }
+    return result;
+}
 
 class unknown_category_t:
     public std::error_category
@@ -338,7 +356,7 @@ std::unique_ptr<registrar::impl_type> registrar::ptr(std::make_unique<impl_type>
 
 auto
 registrar::add(const std::error_category& ec) -> size_t {
-    size_t index = ptr->hash(ec.name()) | 0xFF;
+    size_t index = hash(ec.name()) | 0xFF;
     return ptr->mapping.apply([&](impl_type::mapping_t& mapping){
         if(mapping.insert({index, &ec}).second) {
             return index;

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -27,28 +27,10 @@
 #include <boost/assign/list_of.hpp>
 #include <boost/bimap.hpp>
 
-#define PROTOTYPES
-#include <mutils/mincludes.h>
-#include <mutils/mhash.h>
-
 using namespace cocaine;
 using namespace cocaine::error;
 
 namespace {
-
-size_t hash(const std::string& data) {
-    unsigned char digest[16] = {};
-    MHASH thread = mhash_init(MHASH_MD5);
-    mhash(thread, data.data(), data.size());
-    mhash_deinit(thread, digest);
-    size_t result = digest[0];
-    // This is requred because of endiannes
-    for(size_t i = 1; i < 8; i++) {
-        result <<= 8;
-        result += digest[i];
-    }
-    return result;
-}
 
 class unknown_category_t:
     public std::error_category
@@ -353,13 +335,6 @@ registrar::impl_type::impl_type() {
 }
 
 std::unique_ptr<registrar::impl_type> registrar::ptr(std::make_unique<impl_type>());
-
-auto
-registrar::add(const std::error_category& ec) -> size_t {
-    size_t index = hash(ec.name()) | 0xFF;
-    add(ec, index);
-    return index;
-}
 
 auto
 registrar::add(const std::error_category& ec, size_t index) -> void {


### PR DESCRIPTION
subj. This is needed because std::hash can differ on different platforms and we need consistency in category ids