### PR TITLE
Add generic category

### DIFF
--- a/include/cocaine/traits/attributes.hpp
+++ b/include/cocaine/traits/attributes.hpp
@@ -23,6 +23,9 @@
 
 #include "cocaine/traits.hpp"
 
+#include <blackhole/attribute.hpp>
+#include <blackhole/extensions/writer.hpp>
+
 // NOTE: You should manually include the <blackhole/attribute.hpp> header file BEFORE this include.
 // Such restrictment is required to avoid exporting Blackhole API.
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -75,11 +75,7 @@ public:
     {
         const holder_t scoped(*m_log, {{"source", "core"}});
 
-        auto config_severity = m_config->logging().severity();
-        auto filter = [=](filter_t::severity_t severity, filter_t::attribute_pack&) -> bool {
-            return severity >= config_severity || !trace_t::current().empty();
-        };
-        logger_filter(filter_t(std::move(filter)));
+        reset_logger_filter();
 
         COCAINE_LOG_INFO(m_log, "initializing the core");
 
@@ -166,6 +162,16 @@ public:
     logger_filter(filter_t new_filter) {
         m_log->filter(std::move(new_filter));
     }
+
+    void
+    reset_logger_filter() {
+        auto config_severity = m_config->logging().severity();
+        auto filter = [=](filter_t::severity_t severity, filter_t::attribute_pack&) -> bool {
+            return severity >= config_severity || !trace_t::current().empty();
+        };
+        logger_filter(filter_t(std::move(filter)));
+    }
+
 
     const api::repository_t&
     repository() const {
@@ -304,6 +310,8 @@ public:
 
         // Destroy the service objects.
         actors.clear();
+
+        reset_logger_filter();
 
         COCAINE_LOG_INFO(m_log, "core has been terminated");
     }

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -331,6 +331,7 @@ registrar::impl_type::impl_type() {
         (0x09, &security_category()                 )
         (0x0A, &locator_category()                  )
         (0x0B, &unicorn_category()                  )
+        (0x0C, &std::generic_category()             )
         (0xFF, &unknown_category()                  );
 }
 


### PR DESCRIPTION
fix bugs:
  * Add missing generic category in registrar map
  * Implicitly unregister context_filter in terminate() as function can refer to unloadable plugin, which will cause crash.
  * add missing includes to traits