### PR TITLE
Do not throw on duplicate category insertion if they are really the same

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-core (0.12.8.4+nmu1) unstable; urgency=low
+
+  * Non-maintainer upload.
+  * Ignore adding same category at the same index
+
+ -- Anton Matveenko <antmat@me.com>  Mon, 18 Apr 2016 14:51:29 +0300
+
 cocaine-core (0.12.8.3+nmu1) unstable; urgency=low
 
   * Non-maintainer upload.


### PR DESCRIPTION
Subj. This is needed if we create more than one context_t instance in the same process.