### PR TITLE
Debianization fix

### DIFF
--- a/debian/cocaine-v12-runtime.default
+++ b/debian/cocaine-v12-runtime.default
@@ -1,2 +1,3 @@
 CONFIG_PATH="/etc/cocaine/cocaine-default.conf"
 RUNTIME_PATH="/var/run/cocaine"
+DISABLE_COCAINE_SERVICE=true

--- a/debian/cocaine-v12-runtime.init
+++ b/debian/cocaine-v12-runtime.init
@@ -25,6 +25,11 @@ SCRIPTNAME=/etc/init.d/$NAME
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
+if [ "$DISABLE_COCAINE_SERVICE" = true ] then
+	echo "Cocaine service is disabled. Enable it in /etc/default/$NAME"
+	exit 0
+fi
+
 PIDFILE=/var/run/cocaine/runtime.pid
 
 # Load the VERBOSE setting and other rcS variables

--- a/debian/cocaine-v12-runtime.init
+++ b/debian/cocaine-v12-runtime.init
@@ -25,7 +25,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
-if [ "$DISABLE_COCAINE_SERVICE" = true ] then
+if [ "$DISABLE_COCAINE_SERVICE" = true ]; then
 	echo "Cocaine service is disabled. Enable it in /etc/default/$NAME"
 	exit 0
 fi

--- a/debian/rules
+++ b/debian/rules
@@ -1,11 +1,18 @@
 #!/usr/bin/make -f
 
-include /usr/share/cdbs/1/class/cmake.mk
-include /usr/share/cdbs/1/rules/debhelper.mk
+# Uncomment this to turn on verbose mode.
+#export DH_VERBOSE=1
+export DEB_BUILD_OPTIONS=parallel=$(shell grep -c ^processor /proc/cpuinfo)
 
-DEB_DBG_PACKAGES := cocaine-v12-dbg
-DEB_DH_INSTALLINIT_ARGS := -r
-
-install/cocaine-v12-runtime::
+override_dh_auto_install:
 	install -d $(DEB_DESTDIR)etc/cocaine
+	install -d $(DEB_DESTDIR)usr/share/doc/libcocaine-dev/
 	install -m644 debian/cocaine-runtime.conf $(DEB_DESTDIR)etc/cocaine/cocaine-default.conf
+	install -m644 AUTHORS $(DEB_DESTDIR)usr/share/doc/libcocaine-dev/AUTHORS
+	dh_auto_install
+
+override_dh_strip:
+	dh_strip --dbg-package=cocaine-v12-dbg
+
+%:
+	dh $@ --parallel

--- a/debian/rules
+++ b/debian/rules
@@ -1,18 +1,13 @@
 #!/usr/bin/make -f
 
-# Uncomment this to turn on verbose mode.
-#export DH_VERBOSE=1
-export DEB_BUILD_OPTIONS=parallel=$(shell grep -c ^processor /proc/cpuinfo)
+include /usr/share/cdbs/1/class/cmake.mk
+include /usr/share/cdbs/1/rules/debhelper.mk
 
-override_dh_auto_install:
+DEB_DBG_PACKAGES := cocaine-v12-dbg
+DEB_DH_INSTALLINIT_ARGS := -r
+DEB_BUILD_PARALLEL := true
+DEB_PARALLEL_JOBS := $(shell grep -c ^processor /proc/cpuinfo)
+
+install/cocaine-v12-runtime::
 	install -d $(DEB_DESTDIR)etc/cocaine
-	install -d $(DEB_DESTDIR)usr/share/doc/libcocaine-dev/
 	install -m644 debian/cocaine-runtime.conf $(DEB_DESTDIR)etc/cocaine/cocaine-default.conf
-	install -m644 AUTHORS $(DEB_DESTDIR)usr/share/doc/libcocaine-dev/AUTHORS
-	dh_auto_install
-
-override_dh_strip:
-	dh_strip --dbg-package=cocaine-v12-dbg
-
-%:
-	dh $@ --parallel

--- a/debian/rules
+++ b/debian/rules
@@ -5,8 +5,6 @@ include /usr/share/cdbs/1/rules/debhelper.mk
 
 DEB_DBG_PACKAGES := cocaine-v12-dbg
 DEB_DH_INSTALLINIT_ARGS := -r
-DEB_BUILD_PARALLEL := true
-DEB_PARALLEL_JOBS := $(shell grep -c ^processor /proc/cpuinfo)
 
 install/cocaine-v12-runtime::
 	install -d $(DEB_DESTDIR)etc/cocaine


### PR DESCRIPTION
  * Disable cocaine start by default, as it do require additional setup (f.e. plugin install, configuration, etc), and force the user to explicitly enable it in /etc/default/cocaine-v12-runtime
Also this fixes the problem with alternative startup tool usage.
  * Parallel build in debianization to speed up compilation