### PR TITLE
refactor(context): drop useless and senseless terminate method

### DIFF
--- a/include/cocaine/context.hpp
+++ b/include/cocaine/context.hpp
@@ -86,10 +86,6 @@ public:
     virtual
     auto
     engine() -> execution_unit_t& = 0;
-
-    virtual
-    void
-    terminate() = 0;
 };
 
 std::unique_ptr<context_t>

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -308,10 +308,6 @@ main(int argc, char* argv[]) {
     // unlock the mutex, as we don't need it anymore to prevent deadlock with several terminate calls
     lock.unlock();
 
-    // Termination
-    if(context) {
-        context->terminate();
-    }
     hup_handler_cancellation.cancel();
     child_handler_cancellation.cancel();
     context.reset(nullptr);


### PR DESCRIPTION
subj. This also leads to corruption due to second call to 'terminate' during destruction