### PR TITLE
refact(dlopen): use simple dlopen instead of ltdl 

### DIFF
--- a/include/cocaine/errors.hpp
+++ b/include/cocaine/errors.hpp
@@ -50,7 +50,7 @@ enum repository_errors {
     duplicate_component,
     initialization_error,
     invalid_interface,
-    ltdl_error,
+    dlopen_error,
     version_mismatch
 };
 

--- a/include/cocaine/repository.hpp
+++ b/include/cocaine/repository.hpp
@@ -32,8 +32,6 @@
 #include <type_traits>
 #include <vector>
 
-#include <ltdl.h>
-
 namespace cocaine { namespace api {
 
 template<class Category>
@@ -75,13 +73,21 @@ struct plugin_traits {
 // Component repository
 
 class repository_t {
+public:
+    struct
+    dlclose_action_t {
+        void
+        operator()(void* plugin) const;
+    };
+
+private:
+
     COCAINE_DECLARE_NONCOPYABLE(repository_t)
 
     const std::unique_ptr<logging::logger_t> m_log;
 
-    // NOTE: Used to unload all the plugins on shutdown. Cannot use a forward declaration here due
-    // to the implementation details.
-    std::vector<lt_dlhandle> m_plugins;
+    // Pointers returned by dlopen. Used to unload all the plugins on shutdown.
+    std::vector<std::unique_ptr<void, dlclose_action_t>> m_plugins;
 
     typedef std::map<std::string, std::unique_ptr<factory_concept_t>> factory_map_t;
     typedef std::map<std::string, factory_map_t> category_map_t;
@@ -91,8 +97,6 @@ class repository_t {
 public:
     explicit
     repository_t(std::unique_ptr<logging::logger_t> log);
-
-   ~repository_t();
 
     void
     load(const std::vector<std::string>& plugin_dirs);

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -123,7 +123,7 @@ class repository_category_t:
             return "component has failed to intialize";
         if(code == cocaine::error::repository_errors::invalid_interface)
             return "component has an invalid interface";
-        if(code == cocaine::error::repository_errors::ltdl_error)
+        if(code == cocaine::error::repository_errors::dlopen_error)
             return "internal libltdl error";
         if(code == cocaine::error::repository_errors::version_mismatch)
             return "component version requirements are not met";


### PR DESCRIPTION
It provides better error messages and do not add extra dependencies