### PR TITLE
refactor: drop constness from dispatch

### DIFF
--- a/include/cocaine/api/service.hpp
+++ b/include/cocaine/api/service.hpp
@@ -33,7 +33,7 @@ struct service_t {
 
     virtual
     auto
-    prototype() const -> const io::basic_dispatch_t& = 0;
+    prototype() -> io::basic_dispatch_t& = 0;
 
 protected:
     service_t(context_t&, asio::io_service&, const std::string& /* name */, const dynamic_t& /* args */) {

--- a/include/cocaine/detail/service/locator.hpp
+++ b/include/cocaine/detail/service/locator.hpp
@@ -129,7 +129,7 @@ public:
 
     virtual
     auto
-    prototype() const -> const io::basic_dispatch_t&;
+    prototype() -> io::basic_dispatch_t&;
 
     // Cluster API
 

--- a/include/cocaine/detail/service/logging.hpp
+++ b/include/cocaine/detail/service/logging.hpp
@@ -42,7 +42,7 @@ public:
 
     virtual
     auto
-    prototype() const -> const io::basic_dispatch_t&;
+    prototype() -> io::basic_dispatch_t&;
 
 private:
     void

--- a/include/cocaine/detail/service/storage.hpp
+++ b/include/cocaine/detail/service/storage.hpp
@@ -35,7 +35,7 @@ struct storage_t:
 
     virtual
     auto
-    prototype() const -> const io::basic_dispatch_t&;
+    prototype() -> io::basic_dispatch_t&;
 };
 
 }  // namespace service

--- a/include/cocaine/forwards.hpp
+++ b/include/cocaine/forwards.hpp
@@ -142,8 +142,8 @@ struct transport;
 class basic_dispatch_t;
 class basic_upstream_t;
 
-typedef std::shared_ptr<const basic_dispatch_t> dispatch_ptr_t;
-typedef std::shared_ptr<      basic_upstream_t> upstream_ptr_t;
+typedef std::shared_ptr<basic_dispatch_t> dispatch_ptr_t;
+typedef std::shared_ptr<basic_upstream_t> upstream_ptr_t;
 
 template<class>
 struct protocol;

--- a/include/cocaine/rpc/basic_dispatch.hpp
+++ b/include/cocaine/rpc/basic_dispatch.hpp
@@ -53,7 +53,7 @@ public:
 
     virtual
     boost::optional<dispatch_ptr_t>
-    process(const decoder_t::message_type& message, const upstream_ptr_t& upstream) const = 0;
+    process(const decoder_t::message_type& message, const upstream_ptr_t& upstream) = 0;
 
     // Called on abnormal transport destruction. The idea's if the client disconnects unexpectedly,
     // i.e. not reaching the end of the dispatch graph, then some special handling might be needed.
@@ -61,7 +61,7 @@ public:
 
     virtual
     void
-    discard(const std::error_code& ec) const;
+    discard(const std::error_code& ec);
 
     // Observers
 

--- a/include/cocaine/rpc/dispatch.hpp
+++ b/include/cocaine/rpc/dispatch.hpp
@@ -106,7 +106,7 @@ public:
 public:
     virtual
     boost::optional<io::dispatch_ptr_t>
-    process(const io::decoder_t::message_type& message, const io::upstream_ptr_t& upstream) const;
+    process(const io::decoder_t::message_type& message, const io::upstream_ptr_t& upstream);
 
     virtual
     auto
@@ -124,7 +124,7 @@ public:
 
     template<class Visitor>
     auto
-    process(int id, const Visitor& visitor) const -> typename Visitor::result_type;
+    process(int id, const Visitor& visitor) -> typename Visitor::result_type;
 };
 
 template<class Tag>
@@ -359,14 +359,14 @@ dispatch<Tag>::halt() {
 
 template<class Tag>
 boost::optional<io::dispatch_ptr_t>
-dispatch<Tag>::process(const io::decoder_t::message_type& message, const io::upstream_ptr_t& upstream) const {
+dispatch<Tag>::process(const io::decoder_t::message_type& message, const io::upstream_ptr_t& upstream) {
     return process(message.type(), aux::calling_visitor_t(message.headers(), message.args(), upstream));
 }
 
 template<class Tag>
 template<class Visitor>
 typename Visitor::result_type
-dispatch<Tag>::process(int id, const Visitor& visitor) const {
+dispatch<Tag>::process(int id, const Visitor& visitor) {
     typedef typename slot_map_t::mapped_type slot_ptr_type;
 
     const auto slot = m_slots.apply([&](const slot_map_t& mapping) -> slot_ptr_type {

--- a/include/cocaine/rpc/slot.hpp
+++ b/include/cocaine/rpc/slot.hpp
@@ -45,13 +45,13 @@ public:
     typedef typename traits_type::sequence_type sequence_type;
     typedef dispatch<typename traits_type::dispatch_type> dispatch_type;
     typedef upstream<typename traits_type::upstream_type> upstream_type;
-    typedef boost::optional<std::shared_ptr<const dispatch_type>> result_type;
+    typedef boost::optional<std::shared_ptr<dispatch_type>> result_type;
 
     virtual
    ~basic_slot() = default;
 
     virtual
-    boost::optional<std::shared_ptr<const dispatch_type>>
+    boost::optional<std::shared_ptr<dispatch_type>>
     operator()(const meta_type& meta, tuple_type&& args, upstream_type&& upstream) = 0;
 };
 

--- a/include/cocaine/rpc/slot/blocking.hpp
+++ b/include/cocaine/rpc/slot/blocking.hpp
@@ -49,7 +49,7 @@ struct blocking_slot:
     { }
 
     virtual
-    boost::optional<std::shared_ptr<const dispatch_type>>
+    boost::optional<std::shared_ptr<dispatch_type>>
     operator()(const std::vector<hpack::header_t>& headers,
                tuple_type&& args,
                upstream_type&& upstream)
@@ -65,7 +65,7 @@ struct blocking_slot:
         if(is_recursed<Event>::value) {
             return boost::none;
         } else {
-            return boost::make_optional<std::shared_ptr<const dispatch_type>>(nullptr);
+            return boost::make_optional<std::shared_ptr<dispatch_type>>(nullptr);
         }
     }
 };
@@ -90,7 +90,7 @@ struct blocking_slot<Event, ForwardMeta, void>:
     { }
 
     virtual
-    boost::optional<std::shared_ptr<const dispatch_type>>
+    boost::optional<std::shared_ptr<dispatch_type>>
     operator()(const std::vector<hpack::header_t>& headers,
                tuple_type&& args,
                upstream_type&& upstream)
@@ -109,7 +109,7 @@ struct blocking_slot<Event, ForwardMeta, void>:
         if(is_recursed<Event>::value) {
             return boost::none;
         } else {
-            return boost::make_optional<std::shared_ptr<const dispatch_type>>(nullptr);
+            return boost::make_optional<std::shared_ptr<dispatch_type>>(nullptr);
         }
     }
 };
@@ -144,7 +144,7 @@ struct blocking_slot<Event, ForwardMeta, mute_slot_tag>:
     { }
 
     virtual
-    boost::optional<std::shared_ptr<const dispatch_type>>
+    boost::optional<std::shared_ptr<dispatch_type>>
     operator()(const std::vector<hpack::header_t>& headers,
                tuple_type&& args,
                upstream_type&&)
@@ -156,7 +156,7 @@ struct blocking_slot<Event, ForwardMeta, mute_slot_tag>:
         if(is_recursed<Event>::value) {
             return boost::none;
         } else {
-            return boost::make_optional<std::shared_ptr<const dispatch_type>>(nullptr);
+            return boost::make_optional<std::shared_ptr<dispatch_type>>(nullptr);
         }
     }
 };

--- a/include/cocaine/rpc/slot/deferred.hpp
+++ b/include/cocaine/rpc/slot/deferred.hpp
@@ -50,7 +50,7 @@ struct deferred_slot:
     { }
 
     virtual
-    boost::optional<std::shared_ptr<const dispatch_type>>
+    boost::optional<std::shared_ptr<dispatch_type>>
     operator()(const std::vector<hpack::header_t>& headers,
                tuple_type&& args,
                upstream_type&& upstream)
@@ -66,7 +66,7 @@ struct deferred_slot:
         if(is_recursed<Event>::value) {
             return boost::none;
         } else {
-            return boost::make_optional<std::shared_ptr<const dispatch_type>>(nullptr);
+            return boost::make_optional<std::shared_ptr<dispatch_type>>(nullptr);
         }
     }
 };

--- a/src/actor.cpp
+++ b/src/actor.cpp
@@ -146,7 +146,7 @@ actor_t::actor_t(context_t& context, const std::shared_ptr<io_service>& asio,
         context.metrics_hub().counter<std::int64_t>(cocaine::format("{}.connections.rejected", service->prototype().name()))
     })
 {
-    const basic_dispatch_t* prototype = &service->prototype();
+    basic_dispatch_t* prototype = &service->prototype();
 
     // Aliasing the pointer to the service to point to the dispatch (sub-)object.
     m_prototype = dispatch_ptr_t(

--- a/src/dispatch.cpp
+++ b/src/dispatch.cpp
@@ -33,7 +33,7 @@ basic_dispatch_t::~basic_dispatch_t() {
 }
 
 void
-basic_dispatch_t::discard(const std::error_code& COCAINE_UNUSED_(ec)) const {
+basic_dispatch_t::discard(const std::error_code& COCAINE_UNUSED_(ec)) {
     // Empty.
 }
 

--- a/src/service/locator.cpp
+++ b/src/service/locator.cpp
@@ -98,7 +98,7 @@ public:
 
     virtual
     void
-    discard(const std::error_code& ec) const;
+    discard(const std::error_code& ec);
 
 private:
     void
@@ -109,7 +109,7 @@ private:
 };
 
 void
-locator_t::connect_sink_t::discard(const std::error_code& ec) const {
+locator_t::connect_sink_t::discard(const std::error_code& ec) {
     if(ec.value() == 0) return;
 
     COCAINE_LOG_ERROR(parent->m_log, "remote client discarded: [{:d}] {}", ec.value(), ec.message(), attribute_list({
@@ -178,10 +178,10 @@ class locator_t::publish_slot_t: public basic_slot<locator::publish> {
 
         virtual
         void
-        discard(const std::error_code& ec) const { parent->discard(ec, handle); }
+        discard(const std::error_code& ec) { parent->discard(ec, handle); }
     };
 
-    typedef std::shared_ptr<const basic_slot::dispatch_type> result_type;
+    typedef std::shared_ptr<basic_slot::dispatch_type> result_type;
 
     locator_t *const parent;
 
@@ -256,10 +256,10 @@ class locator_t::routing_slot_t: public basic_slot<locator::routing> {
 
         virtual
         void
-        discard(const std::error_code& ec) const { parent->discard(ec, handle); }
+        discard(const std::error_code& ec) { parent->discard(ec, handle); }
     };
 
-    typedef std::shared_ptr<const basic_slot::dispatch_type> result_type;
+    typedef std::shared_ptr<basic_slot::dispatch_type> result_type;
 
     locator_t *const parent;
 
@@ -385,8 +385,8 @@ locator_t::~locator_t() {
     // Empty.
 }
 
-const basic_dispatch_t&
-locator_t::prototype() const {
+basic_dispatch_t&
+locator_t::prototype() {
     return *this;
 }
 

--- a/src/service/logging.cpp
+++ b/src/service/logging.cpp
@@ -100,7 +100,7 @@ logging_t::logging_t(context_t& context, asio::io_service& asio, const std::stri
 }
 
 auto
-logging_t::prototype() const -> const io::basic_dispatch_t& {
+logging_t::prototype() -> io::basic_dispatch_t& {
     return *this;
 }
 

--- a/src/service/storage.cpp
+++ b/src/service/storage.cpp
@@ -294,6 +294,6 @@ storage_t::storage_t(context_t& context, asio::io_service& asio, const std::stri
 }
 
 auto
-storage_t::prototype() const -> const basic_dispatch_t& {
+storage_t::prototype() -> basic_dispatch_t& {
     return *this;
 }


### PR DESCRIPTION
- No longer keep dispatch as const. It should mutate its state,
otherwise it’s useless!
- Drop `const` from prototypes.
- Drop `const` from `dispatch::process` and `dispatch::discard`.