### PR TITLE
refact: RAII wrapper for unicorn scope

### DIFF
--- a/include/cocaine/api/unicorn.hpp
+++ b/include/cocaine/api/unicorn.hpp
@@ -49,6 +49,13 @@ public:
 
 typedef std::shared_ptr<unicorn_scope_t> unicorn_scope_ptr;
 
+class auto_scope_t {
+    unicorn_scope_ptr wrapped;
+public:
+    auto_scope_t(unicorn_scope_ptr wrapped);
+    ~auto_scope_t();
+};
+
 /**
  * Unicorn API
  */

--- a/src/api/unicorn.cpp
+++ b/src/api/unicorn.cpp
@@ -27,6 +27,16 @@
 
 namespace cocaine { namespace api {
 
+auto_scope_t::auto_scope_t(unicorn_scope_ptr wrapped) :
+    wrapped(std::move(wrapped))
+{}
+
+auto_scope_t::~auto_scope_t() {
+    if(wrapped){
+        wrapped->close();
+    }
+}
+
 // Unicorn
 
 unicorn_t::unicorn_t(context_t& /*context*/, const std::string& /*name*/, const dynamic_t& /*args*/) {


### PR DESCRIPTION
Scope is returned by shared_ptr, so we can not rely on dtor to close the scope, this PR provides simple RAII wrapper on shared_ptr on scope.
@3Hren @karitra PTAL