### PR TITLE
fix: auto_scope_t should not be copied

### DIFF
--- a/include/cocaine/api/unicorn.hpp
+++ b/include/cocaine/api/unicorn.hpp
@@ -53,7 +53,13 @@ class auto_scope_t {
     unicorn_scope_ptr wrapped;
 public:
     auto_scope_t(unicorn_scope_ptr wrapped);
+    auto_scope_t(const auto_scope_t&) = delete;
+    auto_scope_t& operator=(const auto_scope_t&) = delete;
+    auto_scope_t(auto_scope_t&&);
+    auto_scope_t& operator=(auto_scope_t&&);
     ~auto_scope_t();
+private:
+    auto close() -> void;
 };
 
 /**

--- a/src/api/unicorn.cpp
+++ b/src/api/unicorn.cpp
@@ -31,7 +31,22 @@ auto_scope_t::auto_scope_t(unicorn_scope_ptr wrapped) :
     wrapped(std::move(wrapped))
 {}
 
+auto_scope_t::auto_scope_t(auto_scope_t&& other) :
+    wrapped(std::move(other.wrapped))
+{}
+
+auto_scope_t& auto_scope_t::operator=(auto_scope_t&& other)
+{
+    close();
+    wrapped = std::move(other.wrapped);
+    return *this;
+}
+
 auto_scope_t::~auto_scope_t() {
+    close();
+}
+
+auto auto_scope_t::close() -> void {
     if(wrapped){
         wrapped->close();
     }


### PR DESCRIPTION
Coping auto_scope would close scope, so we need to disable it, leaving only move semantics.
In fact it is the same code as it initially was in #186, but without default empty ctor.