### PR TITLE
refact: allow acces to asio in executor

### DIFF
--- a/include/cocaine/executor/asio.hpp
+++ b/include/cocaine/executor/asio.hpp
@@ -26,6 +26,9 @@ public:
     auto
     spawn(work_t work) -> void override;
 
+    auto
+    asio() -> asio::io_service&;
+
 private:
     asio::io_service io_loop;
     boost::optional<asio::io_service::work> work;

--- a/src/executor/asio.cpp
+++ b/src/executor/asio.cpp
@@ -23,6 +23,11 @@ owning_asio_t::spawn(work_t work) -> void {
     io_loop.post(std::move(work));
 }
 
+auto
+owning_asio_t::asio() -> asio::io_service& {
+    return io_loop;
+}
+
 borrowing_asio_t::borrowing_asio_t(asio::io_service& _io_loop) :
     io_loop(_io_loop)
 {}


### PR DESCRIPTION
I'm tired of creating threads to run asio inside. chamber_t is private and do some extra work (measures load).
I suggest either expose asio from asio_owning_t (as in this PR) or make chamber_t public and use it when we need to create a thread with asio inside.

@3Hren @karitra PTAL