### PR TITLE
Reduce complexity

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-core (0.12.14.19) unstable; urgency=low
+
+  * Non-maintainer upload.
+  * Perf: Reduce complexity in locator (on_cluster and on_routing).
+
+ -- Anton Matveenko <antmat@me.com>  Fri, 13 Oct 2017 14:13:07 +0300
+
 cocaine-core (0.12.14.18) unstable; urgency=low
 
   * Non-maintainer upload.


### PR DESCRIPTION
subj. This on_cluster code perform about 20 times faster (both trusty and mac os x 10.11) with 1000 dummy hosts in m_clients map. 
I don't use std::reference_wrapper as I'm too dumb for such algorithms, so they look scary to me.