### PR TITLE
Feat/dynamic endpoint

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cocaine-core (0.12.14.21) unstable; urgency=low
+
+  * Non-maintainer upload.
+  * Fixed: Move dynamic constructors and converters from plugins
+    to prevent ODR violation.
+
+ -- Anton Matveenko <antmat@me.com>  Thu, 23 Nov 2017 19:57:07 +0300
+
 cocaine-core (0.12.14.20) unstable; urgency=low
 
   * Non-maintainer upload.

--- a/include/cocaine/dynamic/constructors/endpoint.hpp
+++ b/include/cocaine/dynamic/constructors/endpoint.hpp
@@ -1,0 +1,44 @@
+/*
+    Copyright (c) 2017+ Anton Matveenko <antmat@me.com>
+    Copyright (c) 2017+ Other contributors as noted in the AUTHORS file.
+
+    This file is part of Cocaine.
+
+    Cocaine is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Cocaine is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cocaine/dynamic.hpp>
+
+#include <asio/ip/tcp.hpp>
+
+namespace cocaine {
+
+template<>
+struct dynamic_constructor<asio::ip::tcp::endpoint> {
+    static const bool enable = true;
+
+    static inline
+    void
+    convert(const asio::ip::tcp::endpoint& from, dynamic_t::value_t& to) {
+        dynamic_constructor<dynamic_t::array_t>::convert(dynamic_t::array_t(), to);
+        auto& array = boost::get<detail::dynamic::incomplete_wrapper<dynamic_t::array_t>>(to).get();
+        array.resize(2);
+        array[0] = from.address().to_string();
+        array[1] = from.port();
+    }
+};
+
+} // namespace cocaine

--- a/include/cocaine/dynamic/constructors/set.hpp
+++ b/include/cocaine/dynamic/constructors/set.hpp
@@ -1,0 +1,47 @@
+/*
+    Copyright (c) 2017+ Anton Matveenko <antmat@me.com>
+    Copyright (c) 2017+ Other contributors as noted in the AUTHORS file.
+
+    This file is part of Cocaine.
+
+    Cocaine is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Cocaine is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cocaine/dynamic.hpp>
+
+#include <set>
+
+namespace cocaine {
+
+template<class T>
+struct dynamic_constructor<std::set<T>> {
+    static const bool enable = true;
+
+    static inline
+    void
+    convert(const std::set<T>& from, dynamic_t::value_t& to) {
+        dynamic_constructor<dynamic_t::array_t>::convert(dynamic_t::array_t(), to);
+
+        auto& array = boost::get<detail::dynamic::incomplete_wrapper<dynamic_t::array_t>>(to).get();
+        array.reserve(from.size());
+
+        for(const auto& e: from) {
+            array.emplace_back(e);
+        }
+    }
+};
+
+} // namespace cocaine

--- a/include/cocaine/dynamic/constructors/shared_ptr.hpp
+++ b/include/cocaine/dynamic/constructors/shared_ptr.hpp
@@ -1,0 +1,44 @@
+/*
+    Copyright (c) 2017+ Anton Matveenko <antmat@me.com>
+    Copyright (c) 2017+ Other contributors as noted in the AUTHORS file.
+
+    This file is part of Cocaine.
+
+    Cocaine is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Cocaine is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cocaine/dynamic.hpp>
+
+#include <memory>
+
+namespace cocaine {
+
+template<class T>
+struct dynamic_constructor<std::shared_ptr<T>> {
+    static const bool enable = true;
+
+    static inline
+    void
+    convert(const std::shared_ptr<T>& from, dynamic_t::value_t& to) {
+        if(from) {
+            dynamic_constructor<typename std::remove_const<T>::type>::convert(*from, to);
+        } else {
+            to = dynamic_t::null_t();
+        }
+    }
+};
+
+} // namespace cocaine

--- a/include/cocaine/dynamic/converters/endpoint.hpp
+++ b/include/cocaine/dynamic/converters/endpoint.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cocaine/dynamic.hpp>
+#include <cocaine/errors.hpp>
+#include <cocaine/format/dynamic.hpp>
+
+#include <asio/ip/tcp.hpp>
+
+namespace cocaine {
+
+template<>
+struct dynamic_converter<asio::ip::tcp::endpoint> {
+    typedef asio::ip::tcp::endpoint result_type;
+
+    static const bool enable = true;
+
+    static inline
+    result_type
+    convert(const dynamic_t& from) {
+        if (!from.is_array() || from.as_array().size() != 2) {
+            throw error_t("invalid dynamic value for endpoint deserialization {}", from);
+        }
+        auto ep_pair = from.as_array();
+        if (!ep_pair[0].is_string() || !ep_pair[1].is_uint()) {
+            throw error_t("invalid dynamic value for endpoint deserialization", from);
+        }
+        std::string host = ep_pair[0].to<std::string>();
+        unsigned short int port = ep_pair[1].to<unsigned short int>();
+        asio::ip::tcp::endpoint result(asio::ip::address::from_string(host), port);
+        return result;
+    }
+
+    static inline
+    bool
+    convertible(const dynamic_t& from) {
+        return from.is_array() &&
+               from.as_array().size() == 2 &&
+               from.as_array()[0].is_string() &&
+               (from.as_array()[1].is_uint() || from.as_array()[1].is_int());
+    }
+};
+
+
+} // namespace cocaine


### PR DESCRIPTION
This PR moves all unspecific dynamic converters/constructors to core from plugins to prevent ODR possible ODR violation. PR in plugins will follow
@3Hren PTAL