### PR TITLE
Fix race between socket close and async calls by stream

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cocaine-core (0.12.15.0) unstable; urgency=low
+
+  * Fixed: typo
+  * Fixed (BREAKING): race between socket close and async calls by stream
+
+ -- Kirill Smorodinnikov <shaitkir@gmail.com>  Thu, 19 Apr 2018 11:31:41 +0300
+
 cocaine-core (0.12.14.25) unstable; urgency=low
 
   * Fixed: typo

--- a/include/cocaine/rpc/asio/readable_stream.hpp
+++ b/include/cocaine/rpc/asio/readable_stream.hpp
@@ -90,7 +90,7 @@ public:
 
         if(bytes_pending * 2 >= m_ring.size()) {
             // The total size of unprocessed data in larger than half the size of the ring, so grow
-            // the ring in order to accomodate more data.
+            // the ring in order to accommodate more data.
             m_ring.resize(m_ring.size() * 2);
         }
 

--- a/include/cocaine/rpc/asio/transport.hpp
+++ b/include/cocaine/rpc/asio/transport.hpp
@@ -57,6 +57,8 @@ struct transport {
 
    ~transport() {
         try {
+            reader->stop();
+            writer->stop();
             socket->shutdown(socket_type::shutdown_both);
             socket->close();
         } catch(...) {


### PR DESCRIPTION
The race leads to crash when streams try to concurrently perform asynchronous operation on closed socket.